### PR TITLE
Force attachment links in the last answer to open in…

### DIFF
--- a/assessment/displayq2.php
+++ b/assessment/displayq2.php
@@ -2031,7 +2031,8 @@ function makeanswerbox($anstype, $qn, $la, $options,$multi,$colorbox='') {
 					if (strpos($m[0],'target=')===false) {
 						$ret = '<a target="_blank" '.substr($m[0], 2);
 					} else {
-						$ret = $m[0];
+						//force links in the last answer (from attach.js) to open in a new window to prevent manual scores and feedback from being lost
+						$ret = preg_replace("/target=\"_self/","target=\"_new",$m[0]);
 					}
 					$url = $m[1];
 					$extension = substr($url,strrpos($url,'.')+1,3);


### PR DESCRIPTION
… a new window to prevent loss of unsaved feedback or manual scores.

If while grading an essay question, an instructor clicks an attachment link to view a student's attachment, open the link in a new window/tab so any unsaved feedback or manual scoring are not lost.