### PR TITLE
Prevent iterating over empty outcome arrays

### DIFF
--- a/course/addoutcomes.php
+++ b/course/addoutcomes.php
@@ -141,7 +141,7 @@ while ($row = mysql_fetch_row($result)) {
 $cnt = 0;
 function printoutcome($arr) {
 	global $outcomeinfo,$cnt;
-	foreach ($arr as $item) {
+	foreach (is_array($arr)?$arr:array() as $item) {
 		if (is_array($item)) { //is outcome group
 			echo '<li class="blockli" id="grp'.$cnt.'"><span class=icon style="background-color:#66f">G</span> ';
 			echo '<input class="outcome" type="text" size="60" id="g'.$cnt.'" value="'.htmlentities($item['name']).'" onkeyup="txtchg()"> ';

--- a/course/categorize.php
+++ b/course/categorize.php
@@ -75,7 +75,7 @@ END;
 	$outcomes = array();
 	function flattenarr($ar) {
 		global $outcomes;
-		foreach ($ar as $v) {
+		foreach (is_array($ar)?$ar:array() as $v) {
 			if (is_array($v)) { //outcome group
 				$outcomes[] = array($v['name'], 1);
 				flattenarr($v['outcomes']);

--- a/course/copyitems.php
+++ b/course/copyitems.php
@@ -218,7 +218,7 @@ if (!(isset($teacherid))) {
 					$row = mysql_fetch_row($result);
 					function updateoutcomes(&$arr) {
 						global $outcomes;
-						foreach ($arr as $k=>$v) {
+						foreach (is_array($arr)?$arr:array() as $k=>$v) {
 							if (is_array($v)) {
 								updateoutcomes($arr[$k]['outcomes']);
 							} else {


### PR DESCRIPTION
I used this syntax to avoid indenting the entire block so it has a clean line-diff.  Happy to use another syntax if preferable.