### PR TITLE
change embedded frame post message to a json string

### DIFF
--- a/OEAembedq.php
+++ b/OEAembedq.php
@@ -153,7 +153,7 @@ if (isset($QS['showscored'])) {
 	
 	echo '<script type="text/javascript">
 	$(function() {
-		window.parent.postMessage("updatescore='.$signed.'","*");
+		window.parent.postMessage(JSON.stringify({subject: "lti.ext.mom.updateScore", jwt: "'.$signed.'", frame_id: ' . $qsetid . '}), "*");
 	});
 	</script>';
 	if ($scoredonsubmit) {
@@ -225,12 +225,12 @@ echo '<script type="text/javascript">
 	if (MathJax) {
 		MathJax.Hub.Queue(function () {
 			var height = document.body.scrollHeight;
-			window.parent.postMessage("action=resize&id='.$qsetid.'&height="+height,"*");
+			window.parent.postMessage(JSON.stringify({subject: "lti.frameResize", height: height, frame_id: '.$qsetid.'}), "*");
 		});
 	} else {
 		$(function() {
 			var height = document.body.scrollHeight;
-			window.parent.postMessage("action=resize&id='.$qsetid.'&height="+height,"*");
+			window.parent.postMessage(JSON.stringify({subject: "lti.frameResize", height: height, frame_id: '.$qsetid.'}), "*");
 		});
 	}
 	</script>';


### PR DESCRIPTION
This allows the data to be parsed a bit easier on the receiving end.

You can receive these messages with something like:
```
  window.addEventListener('message', function (e) {
    try {
      var message = JSON.parse(e.data);
      switch (message.subject) {
        case 'lti.frameResize':
          // resize frame using message.height
          break;
        case 'lti.ext.mom.updateScore':
          // handle score
          break;
      }
    } catch (err) {
      (console.error || console.log)('invalid message received from ', e.origin);
    }
  });
```