### PR TITLE
Add button to allow JSON export of assessment questions by id 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.php

--- a/admin/assessmentExport.php
+++ b/admin/assessmentExport.php
@@ -1,0 +1,63 @@
+<?php
+require("../validate.php");
+if(isset($_GET['cid']))
+{
+  //courseid 
+  $cid = $_GET['cid'];
+  //Empty array that will return the blocks and all contents
+  $modules_array= array(); 
+  //returns all blocks based on given course id
+  $modules= returnCourseBlocks($cid);
+  
+  //finds all assessments for each block
+  foreach ($modules as $block) {
+      //creates an empty array to store names of all assessments in current block
+      $assessment_names_array= array(); 
+      //loops through an array of typeid(assessment typeids) in the block
+      foreach($block['items'] as $typeid) {
+        //finds names and ids of all assessments for the given block 
+        $query = "SELECT imas_assessments.name,imas_assessments.id FROM imas_assessments
+        join imas_items 
+        On imas_assessments.id = imas_items.typeid 
+        WHERE imas_items.id = ". $typeid .";" ;    
+        $result = mysql_query($query) or die("Query failed : " . mysql_error());
+        //adds the question ids to its specific assessment name
+        while($assessment = mysql_fetch_array($result)){
+          $AssessmentQuestionIds=returnAssessmentQuestionIds($assessment['id']);
+          $assessment_names_array[$assessment['name']]=$AssessmentQuestionIds;
+        }
+      }    
+      //adds the assessment names to the block array
+      $modules_array[$block['name']]=$assessment_names_array;
+    }
+
+//  exports the modules array as json
+    $outputjson = json_encode($modules_array);
+    header("Content-type: application/json");
+    header('Content-Disposition: attachment; filename="results.json"');
+    header('Content-Length: ' . strlen($outputjson));
+    echo $outputjson;
+}
+
+function returnCourseBlocks($cid){
+  $query = "SELECT itemorder FROM imas_courses WHERE id=" . $cid .";";
+  $result = mysql_query($query) or die("Query failed : " . mysql_error());
+  $items = unserialize(mysql_result($result,0,0));
+  return $items;
+}
+// takes an assessment id and returns all questions in a specific assessment
+function returnAssessmentQuestionIds($assessment_id){
+  $query ="SELECT imas_questions.questionsetid FROM `imas_questions` 
+  join imas_assessments 
+  ON imas_questions.assessmentid = imas_assessments.id
+  WHERE imas_assessments.id =".$assessment_id . ";" ;
+  $result = mysql_query($query) or die("Query failed : " . mysql_error());
+  $questionsetids = [];
+  while($row = mysql_fetch_array($result))
+  $rows[] = $row;
+  foreach($rows as $questionid) {
+    $questionsetids[]=$questionid['questionsetid'];
+  }
+  return $questionsetids;
+}
+?>

--- a/admin/ccexport.php
+++ b/admin/ccexport.php
@@ -29,7 +29,9 @@ echo "<div class=breadcrumb>$breadcrumbbase <a href=\"../course/course.php?cid=$
 if (!isset($CFG['GEN']['noimathasexportfornonadmins']) || $myrights>=75) {
 	echo '<div class="cpmid"><a href="exportitems.php?cid='.$cid.'">Export for another IMathAS system or as a backup for this system</a></div>';
 }
-
+echo "<div class='cpmid'>
+                    <a href='assessmentExport.php?cid=". $_GET['cid']."' name='button'>Export OEA QTI</a>
+                    </div>";
 $path = realpath("../course/files");
 
 if (isset($_GET['delete'])) {


### PR DESCRIPTION
# what
- work in progress!
- added a button to the ccexport page 
- button directs to assessmentexport.php
- currently var_dumps original array, then both var_dumps and echoes JSON and XML for given course > modules  > assessments > question ids 

# why
- to allow integration with Open Assessments via QTI

# test
- in course home page, click on export (under course items)
- on export page click on new button
![image](https://cloud.githubusercontent.com/assets/6107653/16925939/773126b2-4cdb-11e6-99e0-325391776f6c.png)
- should show var dump of the current course with an array of the blocks, their assessments, and the individual assessment questions by id
- the results are also given in XML and JSON

# notes
This is a work in progress, but would love input on how to format, where to place the button, or any other insight you think would be helpful.

