### PR TITLE
Fix for wrong library order in addquestions.php

### DIFF
--- a/course/addquestions.php
+++ b/course/addquestions.php
@@ -777,7 +777,7 @@ if (!(isset($teacherid))) { // loaded by a NON-teacher
 				$lnamesarr[0] = "Unassigned";
 				$libsortorder[0] = 0;
 			}
-			$stm = $DBH->query("SELECT name,id,sortorder FROM imas_libraries WHERE id IN ($llist)");
+			$stm = $DBH->query("SELECT name,id,sortorder FROM imas_libraries WHERE id IN ($llist) ORDER BY FIELD(id,$llist)");
 			while ($row = $stm->fetch(PDO::FETCH_NUM)) {
 				$lnamesarr[$row[1]] = $row[0];
 				$libsortorder[$row[1]] = $row[2];
@@ -811,7 +811,7 @@ if (!(isset($teacherid))) { // loaded by a NON-teacher
 					}
 
 				}
-				$query .= " ORDER BY imas_library_items.libid,imas_questionset.broken,imas_library_items.junkflag,imas_questionset.id";
+				$query .= " ORDER BY FIELD(imas_library_items.libid,$llist),imas_questionset.broken,imas_library_items.junkflag,imas_questionset.id";
 				if ($searchall==1) {
 					$query .= " LIMIT 300";
 					$offset = 0;


### PR DESCRIPTION
Libraries displayed in the Add/Remove Questions page are sorted by the library id and not how they display to the user in libtree2.php iframe. This commit fixes the issue. Detailed description of the problem is below.

Example: 
Let's say that we create two child libraries:
- 01 first
- 02 second

and now we rename them:
- 01 first -> 02 first
- 02 second -> 01 second

Assuming the parent library has Alphabetical sorting. Open the Add/Remove Questions page. We will see the libraries (in libtree2.php iframe) in the order:
- 01 second
- 02 first

But if you select them and click on Search to display all questions we will see that the libraries will be displayed in the order (sorted by the library id):
- 02 first
- 01 second