### PR TITLE
Use empty() instead of count() when checking for errors.

### DIFF
--- a/assess2/scorequestion.php
+++ b/assess2/scorequestion.php
@@ -205,7 +205,7 @@ if (count($qns) > 0) {
     }
 
     $errors = $assess_record->scoreQuestion($qn, $timeactive[$k], $submission, $parts_to_score);
-    if (count($errors)>0) {
+    if (!empty($errors)) {
       $scoreErrors[$qn] = $errors;
     }
   }


### PR DESCRIPTION
It's possible $errors is not always an array. Using `empty()`
allows us to check for false, nulls, empty strings, etc.

OHM-318: High error rate in scorequestion.php
(cherry picked from commit 92837c57c91d44ff7ef9dc9473a6e400f95a95da)