### PR TITLE
Allow defined end messages to appear regardless of the show scores setting

### DIFF
--- a/assess2/getscores.php
+++ b/assess2/getscores.php
@@ -92,13 +92,12 @@ if ($assessInfoOut['submitby'] == 'by_question') {
 }
 
 // get endmsg
-if ($assessInfoOut['showscores'] != 'none') {
   $assessInfoOut['endmsg'] = AssessUtils::getEndMsg(
     $assess_info->getSetting('endmsg'),
     $totalScore,
     $assess_info->getSetting('points_possible')
   );
-}
+
 
 //prep date display
 prepDateDisp($assessInfoOut);

--- a/assess2/scorequestion.php
+++ b/assess2/scorequestion.php
@@ -269,13 +269,12 @@ if ($end_attempt) {
   }
 
   // get endmsg
-  if ($assessInfoOut['showscores'] != 'none') {
     $assessInfoOut['endmsg'] = AssessUtils::getEndMsg(
       $assess_info->getSetting('endmsg'),
       $totalScore,
       $assess_info->getSetting('points_possible')
     );
-  }
+
 
 } else {
   if ($assess_info->getSetting('displaymethod') === 'livepoll') {


### PR DESCRIPTION
This is the change we talked about last week, allowing end messages to appear for all show score settings.