### PR TITLE
Feature.fractowords

### DIFF
--- a/assessment/macros.php
+++ b/assessment/macros.php
@@ -34,7 +34,7 @@ array_push($allowedmacros,"exp","sec","csc","cot","sech","csch","coth","nthlog",
  "getfeedbacktxtcalculated","explode","gettwopointlinedata","getdotsdata",
  "getopendotsdata","gettwopointdata","getlinesdata","getineqdata","adddrawcommand",
  "mergeplots","array_unique","ABarray","scoremultiorder","scorestring","randstate",
- "randstates","prettysmallnumber","makeprettynegative","rawurlencode");
+ "randstates","prettysmallnumber","makeprettynegative","rawurlencode","fractowords");
 function mergearrays() {
 	$args = func_get_args();
 	foreach ($args as $k=>$arg) {
@@ -2222,6 +2222,108 @@ function numtowords($num,$doth=false,$addcontractiontonum=false,$addcommas=false
 
 	}
 	return trim($out);
+}
+
+//fractowords function takes numer and denom and returns the fraction in words.
+//Optional argument: $mixed (use 'mixed' to make a mixed number. Some simplification will be done to the fraction, including
+//simplifying whole numbers, recognizing zero, and neg/neg = pos.)
+//Optional argument: $overby (use 'over' or 'by' to make "five over 12" or "five by 12", respectively. No simplification
+//will be done to the fraction.)
+function fractowords($numer,$denom,$mixed=null,$overby=null) { //optional arguments:  $mixed,$overby
+  {
+      if (is_null($mixed) || $mixed=='')
+      {
+          $mixed = 'no';
+      }
+      if (is_null($overby))
+      {
+          $overby = 'no';
+      }
+  }
+
+
+  if ($mixed=='no') {
+    $int='';
+  }
+  if ($mixed=='mixed') {
+    $hasint=0;
+    if (abs($numer-floor($numer))>1e-9 || abs($denom-floor($denom))>1e-9) { //integers only
+      return '';
+    }
+    if ($denom==0) {
+      return '';
+    }
+    if ($numer==0) {
+      return 'zero';
+    }
+      $numersign=sign($numer);
+      $denomsign=sign($denom);
+      $numernew=abs($numer)%(abs($denom));
+      $numer=abs($numer);
+      $denom=abs($denom);
+      $int=floor($numer/$denom);
+
+      if ($numernew==0) {
+        $int='';
+        $numer=$numer*$numersign;
+        $denom=$denom*$denomsign;
+        return numtowords($numer/$denom);
+      } elseif ($numernew!=0) {
+        if ($int==0) {
+          $numer=$numernew*$numersign*$denomsign;
+          $denom=$denom;
+          $int='';
+      } elseif ($int!=0) {
+            $int=numtowords($int*$numersign*$denomsign).' and ';
+            $numer=$numernew;
+            $denom=$denom;
+      }
+    }
+  } //end mixed
+
+
+  if (abs($numer-floor($numer))>1e-9 || abs($denom-floor($denom))>1e-9) { //integers only
+    return '';
+  }
+  if ($denom==0) {
+    return '';
+  } else {
+    if ($overby=='no') {
+      $top=numtowords($numer);
+      if ($denom==1) {
+        $bot='whole';
+      } elseif ($denom==-1) {
+        $bot='negative whole';
+      } elseif ($denom==2) {
+        if (abs($numer)==1) {
+          $bot='half';
+        } elseif ($numer!=1) {
+          $bot='halve';
+        }
+      } elseif ($denom==-2) {
+        if ($numer==1) {
+          $bot='negative half';
+        } else {
+          $bot='negative halve';
+        }
+      }
+
+      else {
+        $bot=numtowords($denom,$doth=true);
+      }
+
+      if (abs($numer)==1) {
+        return $int.$top.' '.$bot;
+      } else {
+        return $int.$top.' '.$bot.'s';
+      }
+
+    } elseif ($overby=='over') {
+      return $int.numtowords($numer).' over '.numtowords($denom);
+    } elseif ($overby=='by') {
+      return $int.numtowords($numer).' by '.numtowords($denom);
+    }
+  }
 }
 
 $namearray[0] = explode(',',"Aaron,Ahmed,Aidan,Alan,Alex,Alfonso,Andres,Andrew,Antonio,Armando,Arturo,Austin,Ben,Bill,Blake,Bradley,Brayden,Brendan,Brian,Bryce,Caleb,Cameron,Carlos,Casey,Cesar,Chad,Chance,Chase,Chris,Cody,Collin,Colton,Conner,Corey,Dakota,Damien,Danny,Darius,David,Deandre,Demetrius,Derek,Devante,Devin,Devonte,Diego,Donald,Dustin,Dylan,Eduardo,Emanuel,Enrique,Erik,Ethan,Evan,Francisco,Frank,Gabriel,Garrett,Gerardo,Gregory,Ian,Isaac,Jacob,Jaime,Jake,Jamal,James,Jared,Jason,Jeff,Jeremy,Jesse,John,Jordan,Jose,Joseph,Josh,Juan,Julian,Julio,Justin,Juwan,Keegan,Ken,Kevin,Kyle,Landon,Levi,Logan,Lucas,Luis,Malik,Manuel,Marcus,Mark,Matt,Micah,Michael,Miguel,Nate,Nick,Noah,Omar,Paul,Quinn,Randall,Ricardo,Ricky,Roberto,Roy,Russell,Ryan,Salvador,Sam,Santos,Scott,Sergio,Shane,Shaun,Skyler,Spencer,Stephen,Taylor,Tevin,Todd,Tom,Tony,Travis,Trent,Trevor,Trey,Tristan,Tyler,Wade,Warren,Wyatt,Zach");

--- a/assessment/macros.php
+++ b/assessment/macros.php
@@ -2224,29 +2224,13 @@ function numtowords($num,$doth=false,$addcontractiontonum=false,$addcommas=false
 	return trim($out);
 }
 
-//fractowords function takes numer and denom and returns the fraction in words.
-//Optional argument: $mixed (use 'mixed' to make a mixed number. Some simplification will be done to the fraction, including
-//simplifying whole numbers, recognizing zero, and neg/neg = pos.)
-//Optional argument: $overby (use 'over' or 'by' to make "five over 12" or "five by 12", respectively. No simplification
-//will be done to the fraction.)
-function fractowords($numer,$denom,$mixed=null,$overby=null) { //optional arguments:  $mixed,$overby
-  {
-      if (is_null($mixed) || $mixed=='')
-      {
-          $mixed = 'no';
-      }
-      if (is_null($overby))
-      {
-          $overby = 'no';
-      }
-  }
+function fractowords($numer,$denom,$options='no') { //optional arguments:  $mixed,$overby
 
-
-  if ($mixed=='no') {
+  if (strpos($options,'mixed')===false) {
     $int='';
   }
-  if ($mixed=='mixed') {
-    $hasint=0;
+  //creates integer and new numerator for mixed numbers
+  if (strpos($options,'mixed')!==false) {
     if (abs($numer-floor($numer))>1e-9 || abs($denom-floor($denom))>1e-9) { //integers only
       return '';
     }
@@ -2279,16 +2263,15 @@ function fractowords($numer,$denom,$mixed=null,$overby=null) { //optional argume
             $denom=$denom;
       }
     }
-  } //end mixed
-
-
+  }
+//handles non-mixed numbers or fractional part of mixed numbers
   if (abs($numer-floor($numer))>1e-9 || abs($denom-floor($denom))>1e-9) { //integers only
     return '';
   }
   if ($denom==0) {
     return '';
   } else {
-    if ($overby=='no') {
+    if (strpos($options,'over')===false && strpos($options,'by')===false) { //not over, not by
       $top=numtowords($numer);
       if ($denom==1) {
         $bot='whole';
@@ -2306,9 +2289,7 @@ function fractowords($numer,$denom,$mixed=null,$overby=null) { //optional argume
         } else {
           $bot='negative halve';
         }
-      }
-
-      else {
+      } else {
         $bot=numtowords($denom,$doth=true);
       }
 
@@ -2318,9 +2299,9 @@ function fractowords($numer,$denom,$mixed=null,$overby=null) { //optional argume
         return $int.$top.' '.$bot.'s';
       }
 
-    } elseif ($overby=='over') {
+    } elseif (strpos($options,'over')!==false) {//over or overby, prefers over
       return $int.numtowords($numer).' over '.numtowords($denom);
-    } elseif ($overby=='by') {
+    } elseif (strpos($options,'by')!==false) {//by or overby
       return $int.numtowords($numer).' by '.numtowords($denom);
     }
   }

--- a/assessment/macros.php
+++ b/assessment/macros.php
@@ -2224,46 +2224,51 @@ function numtowords($num,$doth=false,$addcontractiontonum=false,$addcommas=false
 	return trim($out);
 }
 
-function fractowords($numer,$denom,$options='no') { //optional arguments:  $mixed,$overby
+function fractowords($numer,$denom,$options='no') { //options can combine 'mixed','over','by' and 'literal'
 
   if (strpos($options,'mixed')===false) {
     $int='';
   }
+  $numersign=sign($numer);
+  $denomsign=sign($denom);
   //creates integer and new numerator for mixed numbers
-  if (strpos($options,'mixed')!==false) {
+  if (strpos($options,'mixed')!==false || strpos($options,'literal')===false) { //mixed or not literal
     if (abs($numer-floor($numer))>1e-9 || abs($denom-floor($denom))>1e-9) { //integers only
       return '';
     }
     if ($denom==0) {
+      echo 'Eek! Division by zero.';
       return '';
     }
     if ($numer==0) {
       return 'zero';
     }
-      $numersign=sign($numer);
-      $denomsign=sign($denom);
       $numernew=abs($numer)%(abs($denom));
-      $numer=abs($numer);
+      $numer=abs($numer); //numer and denom now positive
       $denom=abs($denom);
       $int=floor($numer/$denom);
 
-      if ($numernew==0) {
+      if ($numernew==0) {//did fraction reduce to a whole number?
         $int='';
         $numer=$numer*$numersign;
         $denom=$denom*$denomsign;
         return numtowords($numer/$denom);
-      } elseif ($numernew!=0) {
-        if ($int==0) {
+      } elseif ($numernew!=0) {//is there a remainder after dividing?
+        if ($int==0) {//was the fraction proper to begin with?
           $numer=$numernew*$numersign*$denomsign;
-          $denom=$denom;
           $int='';
-      } elseif ($int!=0) {
-            $int=numtowords($int*$numersign*$denomsign).' and ';
-            $numer=$numernew;
-            $denom=$denom;
+      } elseif ($int!=0) {//was the fraction improper to begin with?
+        if (strpos($options,'mixed')===false) {//not mixed and not literal
+          $int='';
+          $numer=$numer*$numersign*$denomsign;
+        } elseif (strpos($options,'mixed')!==false) {//mixed and not literal
+          $int=numtowords($int*$numersign*$denomsign).' and ';
+          $numer=$numernew;
+        }
       }
     }
-  }
+  } //end (mixed or not literal)
+
 //handles non-mixed numbers or fractional part of mixed numbers
   if (abs($numer-floor($numer))>1e-9 || abs($denom-floor($denom))>1e-9) { //integers only
     return '';

--- a/help.html
+++ b/help.html
@@ -2361,15 +2361,16 @@ The following macros help with formatting values for display:
    numtowords(1203,false,true) returns "1023rd"<br/>
    numtowords(1203,false,false,true) returns "one thousand, two hundred three"
   </li>
-<li><strong>fractowords(numerator,denominator,[options])</strong>: Creates a string containing fraction numerator/denominator written out in words. Options is a string that can include combinations
-	of 'mixed', 'over' and 'by'. Using 'over' or 'by' will connect numerator and denominator with those words.
-	Using 'mixed' will simplify fractions that reduce to integers and negative/negative = positive. Does not allow division by zero.<br/>
-	fractowords(5,2) returns "five halves"<br/>
-	fractowords(5,2,'by') returns "five by two"<br/>
-	fractowords(0,-3,'over') returns "zero over negative three"<br/>
-	fractowords(-7,3,'mixed') returns "negative two and one third"<br/>
-	fractowords(-7,-3,'mixed over') returns "two and one over three"<br/>
-	fractowords(0,-3,'mixed') returns "zero"
+<li><strong>fractowords(numerator,denominator,[options])</strong>: Creates a string containing fraction numerator/denominator written out in words. By default, fractions will be reduced to integers if possible,
+	and pos/neg signs will be reduced. Options is a string that can include combinations of 'mixed' or 'literal', and 'over' or 'by'. Using 'over' or 'by' will connect numerator and denominator with that word.
+	Using 'mixed' will output a mixed number, and 'literal' overrides the default simplifications. Does not allow division by zero. If 'over' and 'by' both used, defaults to 'over'. If 'mixed' and 'literal' both used,
+	defaults to 'mixed'.<br/>
+	fractowords(5,-2) returns "negative five halves"<br/>
+	fractowords(6,3) returns "two"<br/>
+	fractowords(-7,4,'mixed') returns "negative one and three fourths"<br/>
+	fractowords(-7,4,'mixed over') returns "negative one and three over four"<br/>
+	fractowords(6,3,'literal') returns "six thirds"<br/>
+	fractowords(6,3,'literal over') returns "six over three"<br/>
 </li>
 <li><strong>numtoroman(number,[uppercase])</strong>:  Converts a number 0.5-3999.5 to a roman numeral string.  Defaults to uppercase; set second parameter to false to
     produce lowercase</li>

--- a/help.html
+++ b/help.html
@@ -2361,6 +2361,16 @@ The following macros help with formatting values for display:
    numtowords(1203,false,true) returns "1023rd"<br/>
    numtowords(1203,false,false,true) returns "one thousand, two hundred three"
   </li>
+<li><strong>fractowords(numerator,denominator,[options])</strong>: Creates a string containing fraction numerator/denominator written out in words. Options is a string that can include combinations
+	of 'mixed', 'over' and 'by'. Using 'over' or 'by' will connect numerator and denominator with those words.
+	Using 'mixed' will simplify fractions that reduce to integers and negative/negative = positive. Does not allow division by zero.<br/>
+	fractowords(5,2) returns "five halves"<br/>
+	fractowords(5,2,'by') returns "five by two"<br/>
+	fractowords(0,-3,'over') returns "zero over negative three"<br/>
+	fractowords(-7,3,'mixed') returns "negative two and one third"<br/>
+	fractowords(-7,-3,'mixed over') returns "two and one over three"<br/>
+	fractowords(0,-3,'mixed') returns "zero"
+</li>
 <li><strong>numtoroman(number,[uppercase])</strong>:  Converts a number 0.5-3999.5 to a roman numeral string.  Defaults to uppercase; set second parameter to false to
     produce lowercase</li>
 <li><strong>prettyint(number)</strong>:  Adds commas in thousands spaces of integers.  Example: prettyint(1234) will return "1,234".  The result is a string, which


### PR DESCRIPTION
fractowords($numer,$denom,[options])
Creates a string containing fraction numerator/denominator written out in words. By default, fractions will be reduced to integers if possible, and pos/neg signs will be reduced. Options is a string that can include combinations of 'mixed' or 'literal', and 'over' or 'by'. Using 'over' or 'by' will connect numerator and denominator with that word. Using 'mixed' will output a mixed number, and 'literal' overrides the default simplifications. Does not allow division by zero. If 'over' and 'by' both used, defaults to 'over'. If 'mixed' and 'literal' both used, defaults to 'mixed'.
fractowords(5,-2) returns "negative five halves"
fractowords(6,3) returns "two"
fractowords(-7,4,'mixed') returns "negative one and three fourths"
fractowords(-7,4,'mixed over') returns "negative one and three over four"
fractowords(6,3,'literal') returns "six thirds"
fractowords(6,3,'literal over') returns "six over three"