### PR TITLE
adds capitalized pronouns to randnamewpronouns() macro

### DIFF
--- a/assessment/macros.php
+++ b/assessment/macros.php
@@ -2420,15 +2420,15 @@ function randnamewpronouns($g=2) {
   
   if ($g==2) {
   	if ($gender==0) { //male
-  		return array(randnames(1,0), _('he'), _('him'), _('his'), _('his'), _('himself'));
+  		return array(randnames(1,0), _('he'), _('him'), _('his'), _('his'), _('himself'), _('He'), _('Him'), _('His'), _('His'), _('Himself'));
   	} else {
-  		return array(randnames(1,1), _('she'), _('her'), _('her'), _('hers'), _('herself'));
+  		return array(randnames(1,1), _('she'), _('her'), _('her'), _('hers'), _('herself'), _('She'), _('Her'), _('Her'), _('Hers'), _('Herself'));
   	}
   } elseif ($g=='neutral') {
     if ($gender==0) { //male
-  		return array(randnames(1,0), _('they'), _('them'), _('their'), _('theirs'), _('themself'));
+  		return array(randnames(1,0), _('they'), _('them'), _('their'), _('theirs'), _('themself'), _('They'), _('Them'), _('Their'), _('Theirs'), _('Themself'));
   	} else {
-  		return array(randnames(1,1), _('they'), _('them'), _('their'), _('theirs'), _('themself'));
+  		return array(randnames(1,1), _('they'), _('them'), _('their'), _('theirs'), _('themself'), _('They'), _('Them'), _('Their'), _('Theirs'), _('Themself'));
   	}
   }
 

--- a/help.html
+++ b/help.html
@@ -2205,8 +2205,9 @@ can be omitted.</p>
 <li><strong>nonzerorrand(min,max,p)</strong>:  Returns a nonzero real number between min and max in steps of p</li>
 <li><strong>randfrom(list or array)</strong>: Return an element of the list/array.  Examples of lists: &quot;2,4,6,8&quot;, or &quot;red,green,blue&quot;</li>
 <li><strong>randname(),randmalename(),randfemalename()</strong>:  Returns a random first name</li>
-<li><strong>randnamewpronouns([option])</strong>:  Returns a random first name with pronouns in the order: subjective, objective, possessive (singular), possessive (plural), reflexive. Can set option to 'neutral' for they/them/their/theirs/themself pronouns.
-	Use: $name,$heshe,$himher,$hisher,$hishers,$himherself = randnamewpronouns()</li>
+<li><strong>randnamewpronouns([option])</strong>:  Returns a random first name with pronouns in the order: subjective, objective, possessive (singular), possessive (plural), reflexive. Can set option to 'neutral' for they/them/their/theirs/themself pronouns.<br />
+For only lower case pronouns, use: $name,$heshe,$himher,$hisher,$hishers,$himherself = randnamewpronouns()<br />
+For lower and upper case pronouns, use: $name,$heshe,$himher,$hisher,$hishers,$himherself,$Heshe,$Himher,$Hisher,$Hishers,$Himherself = randnamewpronouns()</li>
 </ul>
 
 <p>Array randomizers (return multiple results):</p>


### PR DESCRIPTION
I've seen folks request this a few times, so I thought it might be worth addressing.

**Code example:**
$name is my friend, and $heshe loves cats more than I do. $Hisher cat's name is Freddy. $Heshe has white fur with black spots. The cat, I mean...not $name!

**Output:**
Jake is my friend, and he loves cats more than I do. His cat's name is Freddy. He has white fur with black spots. The cat, I mean...not Jake!