### PR TITLE
User Email Addresses for Registraton and Login (Add support for $CFG['emailAsSID'] option)

### DIFF
--- a/actions.php
+++ b/actions.php
@@ -114,35 +114,42 @@ require_once("includes/sanitize.php");
 			$_POST['courseid'] = Sanitize::courseId(trim($_POST['courseselect']));
 			$_POST['ekey'] = '';
 		}
-		if (!isset($_GET['confirmed'])) {
-			//look for existing account. ignore any LTI accounts
-			$stm = $DBH->prepare("SELECT SID FROM imas_users WHERE email=:email AND SID NOT LIKE 'lti-%'");
-			$stm->execute(array(':email'=>$_POST['email']));
-			if ($stm->rowCount()>0) {
-				$nologo = true;
-				require("header.php");
-				echo '<form method="post" action="actions.php?action=newuser&amp;confirmed=true'.$gb.'">';
-				echo '<input type="hidden" name="SID" value="'.Sanitize::encodeStringForDisplay($_POST['SID']).'" />';
-				echo '<input type="hidden" name="firstname" value="'.Sanitize::encodeStringForDisplay($_POST['firstname']).'" />';
-				echo '<input type="hidden" name="lastname" value="'.Sanitize::encodeStringForDisplay($_POST['lastname']).'" />';
-				echo '<input type="hidden" name="email" value="'.Sanitize::encodeStringForDisplay($_POST['email']).'" />';
-				echo '<input type="hidden" name="pw1" value="'.Sanitize::encodeStringForDisplay($_POST['pw1']).'" />';
-				echo '<input type="hidden" name="pw2" value="'.Sanitize::encodeStringForDisplay($_POST['pw2']).'" />';
-				echo '<input type="hidden" name="courseid" value="'.Sanitize::encodeStringForDisplay($_POST['courseid']).'" />';
-				echo '<input type="hidden" name="ekey" value="'.Sanitize::encodeStringForDisplay($_POST['ekey']).'" />';
-				$_SESSION['challenge'] = uniqid();
-				echo '<input type=hidden name=challenge value="'.Sanitize::encodeStringForDisplay($_SESSION['challenge']).'"/>';
-				if (isset($_POST['agree'])) {
-					echo '<input type="hidden" name="agree" value="1" />';
-				}
-				echo '<p> </p>';
-				echo '<p>',_('It appears an account already exists with the same email address you just entered'),'. ';
-				echo sprintf(_('If you are creating an account because you forgot your username, you can %s look up your username %s instead.'),'<a href="forms.php?action=lookupusername">','</a>'),'</p>';
-				echo '<input type="submit" value="',_('Create new account anyways'),'"/>';
-				echo '</form>';
-				require("footer.php");
-				exit;
-			}
+
+		if (isset($CFG['emailAsSID'])) {
+			// set SID, if using emailAsSID
+			$_POST['SID'] = $_POST['email'];
+		} else {
+			// perform the usual email usage check
+    		if (!isset($_GET['confirmed'])) {
+    			//look for existing account. ignore any LTI accounts
+    			$stm = $DBH->prepare("SELECT SID FROM imas_users WHERE email=:email AND SID NOT LIKE 'lti-%'");
+    			$stm->execute(array(':email'=>$_POST['email']));
+    			if ($stm->rowCount()>0) {
+    				$nologo = true;
+    				require("header.php");
+    				echo '<form method="post" action="actions.php?action=newuser&amp;confirmed=true'.$gb.'">';
+    				echo '<input type="hidden" name="SID" value="'.Sanitize::encodeStringForDisplay($_POST['SID']).'" />';
+    				echo '<input type="hidden" name="firstname" value="'.Sanitize::encodeStringForDisplay($_POST['firstname']).'" />';
+    				echo '<input type="hidden" name="lastname" value="'.Sanitize::encodeStringForDisplay($_POST['lastname']).'" />';
+    				echo '<input type="hidden" name="email" value="'.Sanitize::encodeStringForDisplay($_POST['email']).'" />';
+    				echo '<input type="hidden" name="pw1" value="'.Sanitize::encodeStringForDisplay($_POST['pw1']).'" />';
+    				echo '<input type="hidden" name="pw2" value="'.Sanitize::encodeStringForDisplay($_POST['pw2']).'" />';
+    				echo '<input type="hidden" name="courseid" value="'.Sanitize::encodeStringForDisplay($_POST['courseid']).'" />';
+    				echo '<input type="hidden" name="ekey" value="'.Sanitize::encodeStringForDisplay($_POST['ekey']).'" />';
+    				$_SESSION['challenge'] = uniqid();
+    				echo '<input type=hidden name=challenge value="'.Sanitize::encodeStringForDisplay($_SESSION['challenge']).'"/>';
+    				if (isset($_POST['agree'])) {
+    					echo '<input type="hidden" name="agree" value="1" />';
+    				}
+    				echo '<p> </p>';
+    				echo '<p>',_('It appears an account already exists with the same email address you just entered'),'. ';
+    				echo sprintf(_('If you are creating an account because you forgot your username, you can %s look up your username %s instead.'),'<a href="forms.php?action=lookupusername">','</a>'),'</p>';
+    				echo '<input type="submit" value="',_('Create new account anyways'),'"/>';
+    				echo '</form>';
+    				require("footer.php");
+    				exit;
+    			}
+    		}
 		}
 
         $jsondata = [];
@@ -743,14 +750,34 @@ require_once("includes/sanitize.php");
 
 		//DEB $query = "UPDATE imas_users SET FirstName='{$_POST['firstname']}',LastName='{$_POST['lastname']}',email='{$_POST['email']}',msgnotify=$msgnot,qrightsdef=$qrightsdef,deflib='$deflib',usedeflib='$usedeflib',homelayout='$layoutstr',theme='{$_POST['theme']}',listperpage='$perpage'$chguserimg ";
 
-		$stm = $DBH->prepare("SELECT email,lastemail FROM imas_users WHERE id=?");
+		$stm = $DBH->prepare("SELECT SID,email,lastemail FROM imas_users WHERE id=?");
 		$stm->execute(array($userid));
-		list($old_email,$lastemail) = $stm->fetch(PDO::FETCH_NUM);
+		list($old_SID, $old_email,$lastemail) = $stm->fetch(PDO::FETCH_NUM);
 
-		$query = "UPDATE imas_users SET FirstName=:FirstName, LastName=:LastName, email=:email, msgnotify=:msgnotify, qrightsdef=:qrightsdef, deflib=:deflib,";
+		// process SID (needed to support emailAsSID)
+		if (isset($CFG['emailAsSID'])) {
+			if ($old_email != $_POST['email']) {
+				// email was changed; make sure SID can be updated as well
+				require_once("includes/newusercommon.php");
+				if (sidIsAlreadyUsed($_POST['email'])) {
+					require("header.php");
+					echo $pagetopper;
+					echo _("The email you entered is already in use. Please contact your instructor, or try again."),"  <a href=\"forms.php?action=chguserinfo$gb\">",_("Try Again"),"</a>\n";
+					require("footer.php");
+					exit;
+				}
+				// SID can be changed
+				$_POST['SID'] = $_POST['email'];
+			} else {
+				$_POST['SID'] = $old_SID;
+			}
+		} else {
+			$_POST['SID'] = $old_SID;
+		}
+		$query = "UPDATE imas_users SET SID=:SID, FirstName=:FirstName, LastName=:LastName, email=:email, msgnotify=:msgnotify, qrightsdef=:qrightsdef, deflib=:deflib,";
 		$query .= "usedeflib=:usedeflib, homelayout=:homelayout, theme=:theme, listperpage=:listperpage $chguserimg WHERE id=:uid";
 		$stm = $DBH->prepare($query);
-		$stm->execute(array(':FirstName'=>$_POST['firstname'],
+		$stm->execute(array(':SID'=>$_POST['SID'], ':FirstName'=>$_POST['firstname'],
 			':LastName'=>$_POST['lastname'], ':email'=>$_POST['email'], ':msgnotify'=>$msgnot, ':homelayout'=>$layoutstr, ':qrightsdef'=>$qrightsdef,
 			':deflib'=>$deflib, ':usedeflib'=>$usedeflib, ':theme'=>$_POST['theme'], ':listperpage'=>$perpage, ':uid'=>$userid));
 

--- a/admin/forms.php
+++ b/admin/forms.php
@@ -232,9 +232,18 @@ switch($_GET['action']) {
 			}
 			</script>
 		<?php
-		echo "<span class=form>Username:</span>  <input class=form type=text size=40 name=SID ";
+		if (isset($CFG['emailAsSID'])) {
+			// hide the SID field, when using emailAsSID
+		} else {
+    		echo "<span class=form>Username:</span>  <input class=form type=text size=40 name=SID ";
+    		if ($_GET['action'] != "newadmin") {
+    			echo 'value="'.Sanitize::encodeStringForDisplay($line['SID']).'"';
+    		}
+    		echo "><BR class=form>\n";
+		}
+		echo "<span class=form>Email:</span> <input class=form type=email size=40 name=email ";
 		if ($_GET['action'] != "newadmin") {
-			echo 'value="'.Sanitize::encodeStringForDisplay($line['SID']).'"';
+			echo 'value="'.Sanitize::encodeStringForDisplay($line['email']).'"';
 		}
 		echo "><BR class=form>\n";
 		echo "<span class=form>First Name:</span> <input class=form type=text size=40 name=firstname ";
@@ -245,11 +254,6 @@ switch($_GET['action']) {
 		echo "<span class=form>Last Name:</span> <input class=form type=text size=40 name=lastname ";
 		if ($_GET['action'] != "newadmin") {
 			echo 'value="'.Sanitize::encodeStringForDisplay($line['LastName']).'"';
-		}
-		echo "><BR class=form>\n";
-		echo "<span class=form>Email:</span> <input class=form type=email size=40 name=email ";
-		if ($_GET['action'] != "newadmin") {
-			echo 'value="'.Sanitize::encodeStringForDisplay($line['email']).'"';
 		}
 		echo "><BR class=form>\n";
 		if ($_GET['action'] == "newadmin") {

--- a/bltilaunch.php
+++ b/bltilaunch.php
@@ -335,6 +335,10 @@ if (isset($_GET['launch'])) {
 						':email'=>Sanitize::emailAddress($_POST['email']),
 						':msgnotify'=>$msgnot,':groupid'=>$newgroupid));
 				} else {
+					if ($CFG['emailAsSID']) {
+						// set email to SID when using emailAsSID
+						$_POST['email'] = $_POST['SID'];
+					}
 					$rights = 10;
 					$query = "INSERT INTO imas_users (SID,password,rights,FirstName,LastName,email,msgnotify) VALUES ";
 					$query .= '(:SID,:password,:rights,:FirstName,:LastName,:email,:msgnotify)';
@@ -422,9 +426,9 @@ if (isset($_GET['launch'])) {
 			//tying LTI to IMAthAS account
 			//give option to provide existing account info, or provide full new student info
 			if ($allow_acctcreation) {
-				echo "<p>".sprintf(_("If you already have an account on %s, enter your username and password below to enable automated signon from %s"),$installname,Sanitize::encodeStringForDisplay($ltiorgname))."</p>";
+				echo "<p>".sprintf(_("If you already have an account on %s, enter your " . ($CFG['emailAsSID'] ? 'email address' : 'username') . " and password below to enable automated signon from %s"),$installname,Sanitize::encodeStringForDisplay($ltiorgname))."</p>";
 			} else {
-				echo "<p>".sprintf(_("Enter your username and password for %s below to enable automated signon from %s"),$installname,Sanitize::encodeStringForDisplay($ltiorgname))."</p>";
+				echo "<p>".sprintf(_("Enter your " . ($CFG['emailAsSID'] ? 'email address' : 'username') . " and password for %s below to enable automated signon from %s"),$installname,Sanitize::encodeStringForDisplay($ltiorgname))."</p>";
 			}
 			echo "<span class=form><label for=\"curSID\">".Sanitize::encodeStringForDisplay($loginprompt).":</label></span> <input class=form type=text size=12 id=\"curSID\" name=\"curSID\"><BR class=form>\n";
 			echo "<span class=form><label for=\"curPW\">"._("Password:")."</label></span><input class=form type=password size=20 id=\"curPW\" name=\"curPW\"><BR class=form>\n";
@@ -436,7 +440,12 @@ if (isset($_GET['launch'])) {
 				echo "<span class=form><label for=\"pw2\">"._("Confirm password:")."</label></span> <input class=form type=password size=20 id=pw2 name=pw2><BR class=form>\n";
 				echo "<span class=form><label for=\"firstname\">"._("Enter First Name:")."</label></span> <input class=form type=text value=\"".Sanitize::encodeStringForDisplay($deffirst)."\" size=20 id=firstname name=firstname autocomplete=\"given-name\"><BR class=form>\n";
 				echo "<span class=form><label for=\"lastname\">"._("Enter Last Name:")."</label></span> <input class=form type=text value=\"".Sanitize::encodeStringForDisplay($deflast)."\" size=20 id=lastname name=lastname autocomplete=\"family-name\"><BR class=form>\n";
-				echo "<span class=form><label for=\"email\">"._("Enter E-mail address:")."</label></span>  <input class=form type=email value=\"".Sanitize::encodeStringForDisplay($defemail)."\" size=60 id=email name=email autocomplete=\"email\"><BR class=form>\n";
+				if ($CFG['emailAsSID']) {
+					// add dummy hidden email field when using emailAsSID
+					echo '<input type="hidden" value="' . Sanitize::encodeStringForDisplay($defemail) . '" id="email" name="email">';
+				} else {
+					echo "<span class=form><label for=\"email\">"._("Enter E-mail address:")."</label></span>  <input class=form type=email value=\"".Sanitize::encodeStringForDisplay($defemail)."\" size=60 id=email name=email autocomplete=\"email\"><BR class=form>\n";
+				}
 				echo "<span class=form><label for=\"msgnot\">"._("Notify me by email when I receive a new message:")."</label></span><input class=floatleft type=checkbox id=msgnot name=msgnot /><BR class=form>\n";
 				echo "<div class=submit><input type=submit value='"._("Create Account")."'></div>\n";
 				require_once(__DIR__.'/includes/newusercommon.php');
@@ -1927,6 +1936,10 @@ if (isset($_GET['launch'])) {
 						':email'=>Sanitize::emailAddress($_POST['email']),
 						':msgnotify'=>$msgnot, ':groupid'=>$newgroupid));
 				} else {
+					if ($CFG['emailAsSID']) {
+						// set email to SID when using emailAsSID
+						$_POST['email'] = $_POST['SID'];
+					}
 					$rights = 10;
 					$query = "INSERT INTO imas_users (SID,password,rights,FirstName,LastName,email,msgnotify) VALUES ";
 					$query .= "(:SID, :password, :rights, :FirstName, :LastName, :email, :msgnotify)";

--- a/course/listusers.php
+++ b/course/listusers.php
@@ -149,6 +149,11 @@ if (!isset($teacherid)) { // loaded by a NON-teacher
 		$pagetitle = "Enroll a New Student";
 		$placeinhead .= '<script type="text/javascript" src="'.$staticroot.'/javascript/jquery.validate.min.js?v=122917"></script>';
 
+		if (isset($CFG['emailAsSID']) && isset($_POST['email'])) {
+			// set SID, if using emailAsSID
+			$_POST['SID'] = $_POST['email'];
+		}
+
 		if (isset($_POST['SID'])) {
 			require_once("../includes/newusercommon.php");
 			$errors = checkNewUserValidation(array('SID','firstname','lastname','email','pw1'));
@@ -215,36 +220,54 @@ if (!isset($teacherid)) { // loaded by a NON-teacher
 
 		if (isset($_POST['timelimitmult'])) {
 			$msgout = '';
-			if (isset($_POST['SID'])) {
-				if (checkFormatAgainstRegex($_POST['SID'], $loginformat)) {
-					$un = $_POST['SID'];
-					$updateusername = true;
-				} else {
+			if (isset($_POST['SID']) || isset($_POST['OrigEmailForEmailAsSid'])) {
+				if (isset($CFG['emailAsSID'])) {
+					// deal with SID later in email-related code, if using emailAsSID
 					$updateusername = false;
-				}
-				$stm = $DBH->prepare("SELECT id FROM imas_users WHERE SID=:SID");
-				$stm->execute(array(':SID'=>$un));
-				if ($stm->rowCount()>0) {
-					$updateusername = false;
-				}
-				if ($updateusername) {
-					$msgout .= '<p>Username changed to '.Sanitize::encodeStringForDisplay($un).'</p>';
 				} else {
-					$msgout .= '<p>Username left unchanged</p>';
+					if (checkFormatAgainstRegex($_POST['SID'], $loginformat)) {
+						$un = $_POST['SID'];
+						$updateusername = true;
+					} else {
+						$updateusername = false;
+					}
+					// make sure SID is not already used
+					if (sidIsAlreadyUsed($_POST['SID'])) {
+						$updateusername = false;
+					}
+					if ($updateusername) {
+						$msgout .= '<p>Username changed to '.Sanitize::encodeStringForDisplay($un).'</p>';
+					} else {
+						$msgout .= '<p>Username left unchanged</p>';
+					}
 				}
 				$query = "UPDATE imas_users SET FirstName=:FirstName,LastName=:LastName";
-
 				$qarr = array(':FirstName'=>$_POST['firstname'], ':LastName'=>$_POST['lastname']);
 				if ($updateusername) {
 					$query .= ",SID=:SID";
 					$qarr[':SID'] = $un;
 				}
-				if (!preg_match('/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/',$_POST['email']) ||
-				(isset($CFG['acct']['emailFormat']) && !checkFormatAgainstRegex($_POST['email'], $CFG['acct']['emailFormat']))) {
-				$msgout .= '<p>Invalid email address - left unchanged</p>';
-			  } else {
-					$query .= ",email=:email";
-					$qarr[':email'] = $_POST['email'];
+				//if (!preg_match('/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/',$_POST['email'])
+				if (!filter_var($_POST['email'], FILTER_VALIDATE_EMAIL) || (isset($CFG['acct']['emailFormat']) && !checkFormatAgainstRegex($_POST['email'], $CFG['acct']['emailFormat']))) {
+        				$msgout .= '<p>Invalid email address - left unchanged</p>';
+        		} else {
+					if (isset($CFG['emailAsSID'])) {
+    					// perform additional validation of email to insure it is not an alread-registered SID, if using emailAsSID
+    					$email_was_changed = $_POST['OrigEmailForEmailAsSid'] != $_POST['email'];
+    					if ($email_was_changed && sidIsAlreadyUsed($_POST['email'])) {
+    						$msgout .= '<p>email address already in use - left unchanged</p>';
+    					} else {
+    						// set SID and email to same value
+    						$query .= ",SID=:SID";
+    						$qarr[':SID'] = $_POST['email'];
+
+            					$query .= ",email=:email";
+            					$qarr[':email'] = $_POST['email'];
+           				}
+					} else {
+						$query .= ",email=:email";
+						$qarr[':email'] = $_POST['email'];
+					}
 				}
 				if (isset($_POST['doresetpw'])) {
 					if (isset($CFG['acct']['passwordFormat']) && !checkFormatAgainstRegex($_POST['pw1'], $CFG['acct']['passwordFormat'])) {
@@ -267,7 +290,11 @@ if (!isset($teacherid)) { // loaded by a NON-teacher
 				$stm = $DBH->prepare($query);
 				$stm->execute($qarr);
 			} else {
-				$msgout = '<p>Username, name, email, and password left unchanged.</p>';
+				if (isset($CFG['emailAsSID'])) {
+					$msgout = '<p>Name, email, and password left unchanged.</p>';
+				} else {
+       				$msgout = '<p>Username, name, email, and password left unchanged.</p>';
+       			}
 			}
 			$code = $_POST['code'];
 			$section = $_POST['section'];
@@ -564,16 +591,20 @@ if ($overwriteBody==1) {
 ?>
 
 	<form method=post id=pageform class=limitaftervalidate action="listusers.php?cid=<?php echo $cid ?>&newstu=new">
-		<span class=form><label for="SID"><?php echo $loginprompt;?>:</label></span> <input class=form type=text size=12 id=SID name=SID><BR class=form>
-	<span class=form><label for="pw1">Choose a password:</label></span><input class=form type=text size=20 id=pw1 name=pw1><BR class=form>
-	<span class=form><label for="firstname">Enter First Name:</label></span> <input class=form type=text size=20 id=firstname name=firstname><BR class=form>
-	<span class=form><label for="lastname">Enter Last Name:</label></span> <input class=form type=text size=20 id=lastname name=lastname><BR class=form>
-	<span class=form><label for="email">Enter E-mail address:</label></span>  <input class=form type=text size=60 id=email name=email><BR class=form>
-	<span class=form>Section (optional):</span>
+		<?php if (isset($CFG['emailAsSID'])) { ?>
+			<?php // hide the SID field, when using emailAsSID ?>
+		<?php } else { ?>
+			<span class=form><label for="SID"><?php echo $loginprompt;?>:</label></span> <input class=form type=text size=12 id=SID name=SID><BR class=form>
+		<?php } ?>
+		<span class=form><label for="email">Enter E-mail address:</label></span>  <input class=form type=text size=60 id=email name=email><BR class=form>
+		<span class=form><label for="pw1">Choose a password:</label></span><input class=form type=text size=20 id=pw1 name=pw1><BR class=form>
+		<span class=form><label for="firstname">Enter First Name:</label></span> <input class=form type=text size=20 id=firstname name=firstname><BR class=form>
+		<span class=form><label for="lastname">Enter Last Name:</label></span> <input class=form type=text size=20 id=lastname name=lastname><BR class=form>
+		<span class=form>Section (optional):</span>
 		<span class=formright><input type="text" name="section"></span><br class=form>
-	<span class=form>Code (optional):</span>
+		<span class=form>Code (optional):</span>
 		<span class=formright><input type="text" name="code"></span><br class=form>
-	<div class=submit><input type=submit value="Create and Enroll"></div>
+		<div class=submit><input type=submit value="Create and Enroll"></div>
 	</form>
 
 <?php
@@ -595,8 +626,15 @@ if ($overwriteBody==1) {
 		}
 ?>
 		<form enctype="multipart/form-data" id=pageform method=post action="listusers.php?cid=<?php echo $cid ?>&chgstuinfo=true&uid=<?php echo Sanitize::onlyInt($_GET['uid']) ?>" class="limitaftervalidate"/>
-			<span class=form><label for="SID">User Name (login name):</label></span>
-			<input <?php echo $disabled;?> class=form type=text size=20 id=SID name=SID value="<?php echo Sanitize::encodeStringForDisplay($lineStudent['SID']); ?>"/><br class=form>
+			<?php if (isset($CFG['emailAsSID'])) { ?>
+				<?php // create a dummy field, when using emailAsSID ?>
+				<?php if (!$disabled) { ?>
+					<input type="hidden" id="OrigEmailForEmailAsSid" name="OrigEmailForEmailAsSid" value="<?php echo Sanitize::encodeStringForDisplay($lineStudent['email']); ?>" />
+				<?php } ?>
+			<?php } else { ?>
+       			<span class=form><label for="SID">User Name (login name):</label></span>
+       			<input <?php echo $disabled;?> class=form type=text size=20 id=SID name=SID value="<?php echo Sanitize::encodeStringForDisplay($lineStudent['SID']); ?>"/><br class=form>
+			<?php } ?>
 			<span class=form><label for="firstname">First Name:</label></span>
 			<input <?php echo $disabled;?> class=form type=text size=20 id=firstname name=firstname value="<?php echo Sanitize::encodeStringForDisplay($lineStudent['FirstName']); ?>"/><br class=form>
 			<span class=form><label for="lastname">Last Name:</label></span>

--- a/course/managetutors.php
+++ b/course/managetutors.php
@@ -223,7 +223,7 @@ foreach ($tutorlist as $tutor) {
 	</table>
 	<hr/>
 	<p>
-	<b>Add new tutors.</b>  Provide a list of usernames below, separated by commas, to add as tutors.
+	<b>Add new tutors.</b>  Provide a list of  <?php echo isset($CFG['emailAsSID']) ? 'email addresses' : 'usernames' ?> below, separated by commas, to add as tutors.
 	</p>
 	<p>
 	<textarea name="newtutors" rows="3" cols="60"></textarea>

--- a/forms.php
+++ b/forms.php
@@ -45,12 +45,16 @@ switch($_GET['action']) {
 		}
 		echo '<div id="headerforms" class="pagetitle"><h1>',_('New Student Signup'),'</h1></div>';
 		echo "<form id=\"newuserform\" class=limitaftervalidate method=post action=\"actions.php?action=newuser$gb\">\n";
-		echo "<span class=form><label for=\"SID\">$longloginprompt:</label></span> <input class=\"form\" type=\"text\" size=12 id=SID name=SID><BR class=\"form\">\n";
+		if (isset($CFG['emailAsSID'])) {
+			// hide the SID field, when using emailAsSID
+		} else {
+        		echo "<span class=form><label for=\"SID\">$longloginprompt:</label></span> <input class=\"form\" type=\"text\" size=12 id=SID name=SID><BR class=\"form\">\n";
+		}
+		echo "<span class=\"form\"><label for=\"email\">",_('Enter E-mail address:'),"</label></span>  <input class=\"form\" type=\"text\" size=60 id=email name=email autocomplete=\"email\"><BR class=\"form\">\n";
 		echo "<span class=\"form\"><label for=\"pw1\">",_('Choose a password:'),"</label></span><input class=\"form\" type=\"password\" size=20 id=pw1 name=pw1><BR class=\"form\">\n";
 		echo "<span class=\"form\"><label for=\"pw2\">",_('Confirm password:'),"</label></span> <input class=\"form\" type=\"password\" size=20 id=pw2 name=pw2><BR class=\"form\">\n";
 		echo "<span class=\"form\"><label for=\"firstname\">",_('Enter First Name:'),"</label></span> <input class=\"form\" type=\"text\" size=20 id=firstname name=firstname autocomplete=\"given-name\"><BR class=\"form\">\n";
 		echo "<span class=\"form\"><label for=\"lastname\">",_('Enter Last Name:'),"</label></span> <input class=\"form\" type=\"text\" size=20 id=lastname name=lastname autocomplete=\"family-name\"><BR class=\"form\">\n";
-		echo "<span class=\"form\"><label for=\"email\">",_('Enter E-mail address:'),"</label></span>  <input class=\"form\" type=\"text\" size=60 id=email name=email autocomplete=\"email\"><BR class=\"form\">\n";
 		echo "<span class=form><label for=\"msgnot\">",_('Notify me by email when I receive a new message:'),"</label></span><span class=formright><input type=checkbox id=msgnot name=msgnot checked=\"checked\" /></span><BR class=form>\n";
         if (isset($CFG['GEN']['COPPA'])) {
 			echo "<span class=form><label for=\"over13\">",_('I am 13 years old or older'),"</label></span><span class=formright><input type=checkbox name=over13 id=over13 onchange=\"toggleOver13()\"></span><br class=form />\n";
@@ -477,20 +481,26 @@ switch($_GET['action']) {
 		if ($gb == '') {
 			echo "<div class=breadcrumb><a href=\"index.php\">Home</a> &gt; ",_('Username Lookup'),"</div>\n";
 		}
-		echo '<div id="headerforms" class="pagetitle"><h1>',_('Lookup Username'),'</h1></div>';
-		echo "<form id=\"pageform\" method=post action=\"actions.php?action=lookupusername$gb\">\n";
-		echo _("If you can't remember your username, enter your email address below.  An email will be sent to your email address with your username. ");
-		echo "<p><label for=email>",_('Email'),"</label>: <input type=text name=\"email\" id=email /></p>";
-		echo '<script type="text/javascript">
-		$("#pageform").validate({
-			rules: {
-				email: { required: true, email: true}
-			},
-			invalidHandler: function() {setTimeout(function(){$("#pageform").removeClass("submitted").removeClass("submitted2");}, 100)}}
-		);
-		</script>';
-		echo "<p><input type=submit value=\"",_('Submit'),"\" /></p>";
-		echo "</form>";
+		if (isset($CFG['emailAsSID'])) {
+			// just show a message when using emailAsSID
+			echo "<p>Your login username is the email address you entered when you registered with " . $installname . ".</p>";
+			echo "<p><a href=\"index.php\">Return to Login</a></p>";
+		} else {
+    		echo '<div id="headerforms" class="pagetitle"><h1>',_('Lookup Username'),'</h1></div>';
+    		echo "<form id=\"pageform\" method=post action=\"actions.php?action=lookupusername$gb\">\n";
+    		echo _("If you can't remember your username, enter your email address below.  An email will be sent to your email address with your username. ");
+    		echo "<p><label for=email>",_('Email'),"</label>: <input type=text name=\"email\" id=email /></p>";
+    		echo '<script type="text/javascript">
+    		$("#pageform").validate({
+    			rules: {
+    				email: { required: true, email: true}
+    			},
+    			invalidHandler: function() {setTimeout(function(){$("#pageform").removeClass("submitted").removeClass("submitted2");}, 100)}}
+    		);
+    		</script>';
+    		echo "<p><input type=submit value=\"",_('Submit'),"\" /></p>";
+    		echo "</form>";
+		}
 		break;
 	case "forumwidgetsettings":
 		$stm = $DBH->prepare("SELECT hideonpostswidget FROM imas_users WHERE id=:id");

--- a/newinstructor.php.dist
+++ b/newinstructor.php.dist
@@ -37,6 +37,12 @@
 			} else {
 				$md5pw = md5($_POST['pw1']);
 			}
+
+			if (isset($CFG['emailAsSID'])) {
+				// set SID, if using emailAsSID
+				$_POST['SID'] = $_POST['email'];
+			}
+
 			//DB $query = "INSERT INTO imas_users (SID, password, rights, FirstName, LastName, email, homelayout) ";
 			//DB $query .= "VALUES ('{$_POST['username']}','$md5pw',0,'{$_POST['firstname']}','{$_POST['lastname']}','{$_POST['email']}','$homelayout');";
 			//DB mysql_query($query) or die("Query failed : " . mysql_error());
@@ -103,7 +109,12 @@
 	echo "<span class=form>Email Address</span><span class=formright><input type=text id=email name=email value=\"$email\" size=40></span><br class=form />\n";
 	echo "<span class=form>Phone Number</span><span class=formright><input type=text id=phone name=phone value=\"$phone\" size=40></span><br class=form />\n";
 	echo "<span class=form>School/College</span><span class=formright><input type=text id=school name=school value=\"$school\" size=40></span><br class=form />\n";
-	echo "<span class=form>Requested Username</span><span class=formright><input type=text id=SID name=SID value=\"$username\" size=40></span><br class=form />\n";
+
+	if (isset($CFG['emailAsSID'])) {
+		// hide the SID field, when using emailAsSID
+	} else {
+        echo "<span class=form>Requested Username</span><span class=formright><input type=text id=SID name=SID value=\"$username\" size=40></span><br class=form />\n";
+	}
 	echo "<span class=form>Requested Password</span><span class=formright><input type=password id=pw1 name=pw1 size=40></span><br class=form />\n";
 	echo "<span class=form>Retype Password</span><span class=formright><input type=password id=pw2 name=pw2 size=40></span><br class=form />\n";
 	echo "<span class=form>I have read and agree to the Terms of Use (below)</span><span class=formright><input type=checkbox id=agree name=agree></span><br class=form />\n";

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,9 @@ Look to `newinstructor-ipeds.php.dist` for an example of how to collect ipeds da
 account request.  The account approval process will auto-create group associations when 
 account requests are collected with this data.
 
+### Using Email Addresses for Login
+- `$CFG['emailAsSID']`: Set to true if you want users to login using their email address (instead of username, aka "SID"). When true, this option modies appearance and behavior of related forms ("New Student Signup", "New Instructor Account Request", "Modify User Profile", "Admin -> New User", "Admin -> Edit User", "Change Student Info", "Username Lookup"). Be sure to increase the size of the SID field in the imas_users table to match the size of the email field (e.g.: "ALTER TABLE `imas_users` CHANGE `SID` `SID` VARCHAR(100)  CHARACTER SET latin1  COLLATE latin1_swedish_ci  NOT NULL  DEFAULT '';""). Be sure to set the $loginprompt and $longloginprompt vars in config.php to "Email"; also set $loginformat to something like "/^[0-9A-Za-z\\-\\.,\\\\?\/!#@$&():;_\"\']+$/"; Use with caution if you are using batchcreateinstr.php, newinstructor-ipeds.php, or other methods of creating user accounts.
+
 ### Development
 - `$CFG['GEN']['uselocaljs']`: Set to true to use local javascript files instead of CDN versions.  Requires installing a local copy of MathJax in `/mathjax/`.
 


### PR DESCRIPTION
Changes in the Pull request enable the use of email addresses for registration and login. Detailed Development notes are here:
  https://docs.google.com/document/d/1fAhsDDIyJsvnlR79o8W9PcUa1ks4MD3QxC7AzPRbjJQ/edit?usp=sharing

 - When the new $CFG['emailAsSID'] option is enabled, the SID (username) field is hidden from users, so users register and login with their email address
 - Under the hood, the SID field is still used for registration and login, but it is set equal to the email field's value wherever possible (e.g., registration and login forms, and forms that allow for changing of user email addresses).
 - Requires database modifications to increase length of imas_users.SID field to 100
 - Requires modification of $loginprompt, $longloginprompt, and $loginformat vars in config.php
 - Complete usage notes appears in the new 'Using Email Addresses for Login' of readme.md

Files that were not modified (that are related to usernames):
 - batchcreateinstr.php
 - newinstructor-ipeds.php
 - modltidomaincred case in admin/actions.php

Several of the modified forms ("New Instructor Account Request", "Modify User Profile", "Admin -> New User", "Roster->Enroll a New Student") will allow an email address that is in another account's email field (as long as it is unique to the SID field). This will accommodate legacy situations that previously created multiple accounts with the same email.

