### PR TITLE
Library.jsxgraph new

### DIFF
--- a/assessment/libs/jsxgraph.html
+++ b/assessment/libs/jsxgraph.html
@@ -1,0 +1,835 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>JSXG</title>
+
+  <style media="screen">
+    pre {
+      font-family: monospace;
+      border: 2px solid rgb(210,210,210);
+      background-color: rgb(240,240,240);
+      border-radius: 8px;
+      padding: 10px;
+      margin: 0px 20px;
+    }
+  </style>
+</head>
+<body>
+  <h1>jsxgraph Macro Library</h1>
+  <p>JSXGraph Integration functions - Version 1.0</br>by David Flenner</p><p>October 14th, 2020</p>
+  <p><i>Adapted from JSXG library written by Grant Sander</i></p>
+  <hr>
+  <h2>Introduction</h2>
+  <p>This library provides an interface to the mathematics graphics library <a href="http://jsxgraph.uni-bayreuth.de/wp/index.html">JSXGraph</a> 
+	for	iMathAS systems such as MyOpenMath. To use the library, you must first call the function: </p>
+	<pre>loadlibrary("jsxgraph")</pre>
+	<p>	Then you must create a "board" that you will add objects on. You create	a board through a call like:</p>
+	<pre>$board = jsxBoard("rectangular")</pre>
+	<p>Where "rectangular" indicates a standard cartesian coordinate grid. You can also create a "polar" grid, or a "geometry" board that is blank.
+	Once you create the board, you can start adding objects to the board. To add an object, you make a call such as:</p>
+	<pre>$a = jsxPoint($board, [1, 2])</pre>
+	<p>Where $board is the variable name of the board you created, $a is a reference to the point you are making and [1, 2] are the coordinates of the point. 
+	Every object you create can take a number of different options that you can control: color, size, dashes, etc. This is done by passing
+	an optional associative array to the end of your function call. For instance:</p> <pre>$b = jsxPoint($board, [-1, 2], ["color" => "blue"])</pre>
+	<p> This will make a second point on the board that will be blue. See the documentation below for the types of options you can control for each object</p>
+	<p>Another feature of this library is the ability for these objects to interact with each other. You can use the reference variable in the creation
+	of other objects. For instance, you could write:</p> <pre>$c = jsxCircle($board, [$a, $b])</pre><p>This would make a circle that passes through the
+	points $a and $b. The really cool thing is that now if you move points $a or $b on your board, the circle will adjust accordingly!
+	You can even use functions like: $a.X(), or $a.Y() if you want to reference the individual components of the point. 
+	For instance:</p><pre>$f = jsxFunction($board, "(x - $a.X()) * (x - $b.X()))")</pre><p>will create a parabolic graph whose zeros are located at
+	the x-values of points $a and $b, and will automatically adjust every time point $a or $b is moved!</p>
+	<p>To label your objects, this library allows the use of either static or dynamic labeling. If you want to label an object, simply 
+	pass the label text as an option:</p>
+	<pre>$p = jsxPoint($board, [1, 2], ['label' => 'A'])</pre>
+	<p>This will create a point with the label text 'A' attached to it and as you move the point, the label will follow. If you want to
+	customize the label, you can change the 'fontcolor' and the 'fontsize' through $options. All labels	support ASCII math, and that can 
+	be enabled by surrounding your text with ``:</p>
+	<pre>$p = jsxPoint($board, [1, 2], ['label' => '`pi`'])</pre>
+	<p>If you need to express the deriviative of a function, it is best to write f prime (x) in your ASCII Math because writing f'(x) can 
+	confuse the system since ' is used to start and end a string</p>
+	<p>You can also	create dynamic labels by using references to jsx objects in conjunction with javascript. To reference an object 
+	during creation, use the keyword 'this'. For instance, the following code will create a point that is labeled with its coordinates:</p>
+	<pre>$p = jsxPoint($board, [1, 2], ['label' => "'(' + this.X().toFixed(2) + ', ' + this.Y().toFixed(2) + ')'"])</pre>
+	This is obviouly more of an advanced feature, but the library is written with the ability to keep things simple, but allow the 
+	extensibility of advanced constructs so the user can take full advantage of the power of JSX Graph.</p>
+	<p>Lastly, for grading, you can pass important aspects to an answerbox, and all the library needs to know is the question number in the assignment - and
+	the answerbox number if you happen to be using a multipart question.</p><p>You can easily pass the quetion number through the variable [$thisq] that is
+	defined for all questions in an assessment. If you pass: ["answerbox" => [thisq]] for a point object, then you will see the 
+	coordinates of the point show up in the answerbox for this question. You can then grab this data from the answerbox to check an answer.
+	</p><p>I hope you find this library useful and easy to use. I've included a lot of example code below to give you ideas on how to use it. If you create a 
+	question using it, please tag the question with #jsx in the name of the question so its easy for everyone to be able to find these great
+	interactive questions!
+</p>
+   <h3>Known Bugs:</h3>
+   <ul>
+	 <li>When the question type is set to <i>conditional</i> using the old interface, the board can revert to a smaller size after the submit button is pressed. This can 
+		be avoided if the question text is longer than the board display. That prevents the board from being re-drawn in a smaller size.</li>
+	 <li>ticksdistance does not appear to be working with rectangular boards</li>
+   </ul>
+
+<h3>Functions in this Library:</h3>
+
+  <ul>
+    <li><a href="#jsxBoard">jsxBoard</a></li>
+    <li><a href="#jsxSlider">jsxSlider</a></li>
+	<li><a href="#jsxPoint">jsxPoint</a></li>
+	<li><a href="#jsxGlider">jsxGlider</a></li>
+    <li><a href="#jsxFunction">jsxFunction</a></li>
+    <li><a href="#jsxParametric">jsxParametric</a></li>
+    <li><a href="#jsxPolar">jsxPolar</a></li>
+    <li><a href="#jsxCircle">jsxCircle</a></li>
+    <li><a href="#jsxPolygon">jsxPolygon</a></li>
+    <li><a href="#jsxLine">jsxLine</a></li>
+	<li><a href="$jsxSegment">jsxSegment</a></li>
+	<li><a href="#jsxRay">jsxRay</a></li>
+    <li><a href="#jsxVector">jsxVector</a></li>
+	<li><a href="#jsxTangent">jsxTangent</a></li>
+    <li><a href="#jsxAngle">jsxAngle</a></li>
+	<li><a href="#jsxText">jsxText</a></li>
+	<li><a href="#jsxIntegral">jsxIntegral</a></li>
+	<li><a href="#jsxRiemannSum">jsxRiemannSum</a></li>
+	<li><a href="#jsxSuspendUpdate">jsxSuspendUpdate</a></li>
+	<li><a href="#jsxUnsuspendUpdate">jsxUnsuspendUpdate</a></li>
+	<li><a href="$jsx_getCoords">jsx_getCoords</a></li>
+	<li><a href="#jsx_getXCoord">jsx_getXCoord</a></li>
+	<li><a href="#jsx_getYCoord">jsx_getYCoord</a></li>
+
+  </ul>
+
+  <h2><a style="color:blue" name="jsxBoard">jsxBoard($type, <i>[$options]</i>)</a></h2>
+  <p>This function creates a jsx board that allows you to add jsx objects on to. You then display the graph in the question text by 
+	adding the $board where you would like the graph to display. The board <i>$type</i> must be specified as one of:</p>
+  <ul>
+	<li><i>rectangular</i> - a standard cartesian coordinate system is drawn on the board</li>
+	<li><i>polar</i> - a polar coordinate grid will be drawn on the board</li>
+	<li><i>geometry</i> - no grid is drawn</li>
+  </ul>
+  <p>Additional optional items can be specified through an associative array:</p>
+  <ul>
+    <li><i>size</i> [(float) width, (float) height] - sets the width/height of the board in pixels. Note that the size of
+		polar graphs must be square, so these only use the provided width</li>
+    <li><i>navbar</i> (boolean) - include navigation buttons</li>
+	<li><i>zoom</i> (boolean) - allow for zooming</li>
+	<li><i>pan</i> (boolean) - alllow for panning</li> 
+	<li><i>centered</i> (boolean) - centers the board on screen if set to true, otherwise the board left-justified</li>
+	<li><i>bounds</i> [(float) xmin, (float) xmax, (float) ymin, (float) ymax] sets the min/max coordinate bounds for the axes. These are
+		ignored in polar graphs.</li>
+  </ul>
+  <p>The following options are used with rectangular boards:</p>
+  <ul>
+    <li><i>axislabel</i> [(string) xLabel, (string) yLabel] - adds labels to the axes, ASCIIMath can be used</li>
+    <li><i>ticksdistance</i> [(float) ticksDistanceX, (float) ticksDistanceY] sets the distance between each major tick on the axes</li>
+    <li><i>minorticks</i> [(int) minorTicksX, (int) minorTicksY] sets the number of minor ticks between each major tick on the axes</li>
+  </ul>
+  <p>The following options are used with polar boards:</p>
+  <ul>
+    <li><i>padtop</i> (boolean) - true adds some space to the top of the board to add sliders</li>
+    <li><i>r</i> - [(float) max, (float) increment] - sets the max/increment for the radius ticks. Defaults to [5, 1]</li>
+	<li><i>theta</i> - [(string) type, (float) increment] sets the type and increment of the theta grid components.<br/>
+		The values of <i>type</i> can be:
+		<ul>
+			<li><i>degrees</i> - Sets up the grid in degree measure, <i>increment</i> is value in degrees</li>
+			<li><i>radians</i> - Sets up the grid in radian measure, <i>increment</i> is a value in radians</li>
+			<li><i>pi</i> - Sets the grid to fractions of pi, <i>increment</i> is the divisor for pi, such as pi/6</li>
+			<li><i>custom</i> - Sets the grid to take <i>increment</i> units to complete a full rotation</li>
+		</ul>
+  </ul>
+  <p>The return of this function is a set of javascript code necessary to display your board, in order to add objects to your board
+	you need to pass this variable to all of your following calls to functions like jsxPoint in order to add additional javascript
+	code to your drawing.</p>
+  <h4>Rectangular Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$ops = [ "size" => [300, 300], "bounds" => [-3,7,-5,5], "axislabel" => ["`x`","`y=x^2`"]]
+$board = jsxBoard('rectangular', $ops)
+  </pre>
+    <h4>Polar Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$ops = ['size' => [400, 400], 'padtop' => true, 'r' => [7,1], 'theta' => ['pi',6], 'pan' => false ]
+$board = jsxBoard('polar', $ops)
+  </pre>
+
+  <!-- jsxSlider -->
+  <h2><a style="color:blue" name="jsxSlider">jsxSlider($board, [$min, $max, $step, <i>$defaultval</i>], <i>[$options]</i>)</a></h2>
+  <p>A slider is like a variable that a user can control the value of on screen. The necessary input values are the minimum value for the
+    variable, the maximum value, and what increment each change to the slider has on the value of the variable. The function returns a reference
+	object to the slider that can be used in other parts of your construction to make interactive elements. $defaultval is an optional
+	parameter and can be used to set the starting position of the slider, if it is omitted then the default value is the midrange.</p>
+  <p>An additional associative array can be provided to have futher control over the look and feel of the slider</p>
+  <ul>
+    <li><i>position</i> [[(float) x1, (float) y1], [(float) x2, (float) y2]] - sets the position of the slider on the board with starting coordinates
+		of (x1, y1), and ending at (x2, y2). By default, sliders are just placed in the upper left-hand corner of the board. Sliders are fixed
+		in such a way that their position is unaffected by zoom and pans. If the position is directly set, then zoom and pans will affect the 
+		position of the slider.</li>
+	<li><i>decimals</i> (integer) - The number of decimals to use for the display of the value.</li>
+	<li><i>name</i> (string) - A text label for the slider, easier to use than the <i>label</i> below, but labels give more control.</li>
+    <li><i>label</i> (string) - A textual string label for the slider, which will display next to the slider value, ASCIIMath can be used</li>
+    <li><i>color</i> (string) - A value indicating the color of the slider ('red', 'green', etc.), an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>fontsize</i> (integer) - Affects the font size of the label text.</li>
+	<li><i>fontcolor</i> (string) - The color for the label text</li>
+	<li><i>answerbox</i> [$thisq, (optional) partNumber] - Places the value the a slider in an answerbox. This will look like: [$thisq] or [$thisq, n] for a multipart question
+		where n is the box number to use.</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+  <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.Value() - the numeric value of the slider</li>
+  </ul>
+  <p>Note: If you set the <i>$step</i> value to be less than 1, you will need to adjust the value of <i>$decimals</i> in order to display these value.</p>
+  <h4>Example 1</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard("rectangular")
+$a = jsxSlider($board, [0, 10, 1], ['answerbox' => [$thisq], 'color' => 'blue'])
+  </pre>
+   <h4>Example 2</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard("rectangular")
+$ops = ['answerbox' => [$thisq], 'position' => [[-4, -4], [1, -4]], 'color' => '#935218', 'decimals' => 1, 'name' => "a", 'fontsize' => 20, 'attributes' => '{ face: "cross" }']
+$a = jsxSlider($board, [-15, 10, 0.1, 8], $ops)
+  </pre>
+
+  <!-- jsxPoint -->
+  <h2><a style="color:blue" name="jsxPoint">jsxPoint($board, [$x $y], <i>[$options]</i>)</a></h2>
+  <p>Adds a point to a $board, which is a variable returned from jsxBoard(). The initial location of the point must be provided as
+	an array of two numbers, or as a string containing a function or a reference to another jsx object. The location of the point can be 
+	linked to an answerbox and updated as the user moves the point around. The return of the function is a reference to this point contained
+	within a string. This reference can be used to link the point to other objects. You can reference the entire point with a variable such
+	as $p, or individual components as $p.X(), or $p.Y().</p>
+  <p>$options is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+    <li><i>fixed</i> (boolean) - makes the point immovable</li>
+    <li><i>color</i> (string) - A value indicating the color of the point ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>size</i> (int) - sets the size of the point, defaults to 2</li>
+    <li><i>face</i> (string) - sets the face of the point, defaults to "circle". Options are: cross, circle, square, plus, diamond, triangleUp, 
+		triangleDown, triangleLeft, triangleRight</li>
+    <li><i>label</i> (string) - attaches a text label to a point, ASCIIMath can be used.</li>
+	<li><i>fontsize</i> (integer) - Affects the font size of the label text.</li>
+	<li><i>fontcolor</i> (string) - The color for the label text</li>
+	<li><i>visible</i> (boolean) - makes the point visible or invisible, useful in creating other objects</li>
+	<li><i>trace</i> (boolean) - If set to true, the point will leave a trail of points on the board as it is moved. The trace points
+		can be erased by pressing the 'o' button on the navigation panel.</li>
+	<li><i>xsnapsize</i> (float) - forces the point to snap to specified intervals in the x-direction</li>
+	<li><i>ysnapsize</i> (float) - forces the point to snap to specified intervals in the y-direction</li>	
+	<li><i>answerbox</i> [$thisq, (optional) partNumber] - Places the value the a slider in an answerbox. This will look like: [$thisq] or [$thisq, n] for a multipart question
+		where n is the box number to use.</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.X() - the x-coordinate of the point</li>
+	<li>.Y() - the y-coordinate of the point</li>
+  </ul>
+  <p>Note: For easier grading you can either set question type to N-Tuple, or use the function jsx_getCoords() to help read the coordinates from the answerbox.</p>
+  <h4>Example 1</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular', ['pan' => false])
+$a = jsxSlider($board, [-3, 3, 1])
+$p = jsxPoint($board, [$a, 1])
+  </pre>
+
+  <h4>Example 2</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$ops = ['size' => 3, 'face' => 'cross', 'label' => "`pi`", 'answerbox' => [$thisq]]
+$p = jsxPoint($board, [2, 1], $ops)
+  </pre>
+
+  <!-- Glider -->
+  <h2><a style="color:blue" name="jsxGlider">jsxGlider($board, [[$x, $y], $obj], <i>[$options]</i>)</a></h2>
+  <p>Attaches a point to another object that has already been created, and restricts the movement of the point to this object. The input variable 
+	$board should be a reference to a board returned by jsxBoard(). The input location will adjust if the coordinates [$x, $y] does not 
+	appear on the curve of $obj, so choosing an $x value of where you want the point to start is genearlly sufficient. $obj must be a reference 
+	returned by another objected created by jsxgraph. Functions, parametric functions, polar graphs, circles, lines, polygons, etc. are all types 
+	of curves that a Glider can be attached to. The return is a reference to the glider object such as $g, which can be used as a reference
+	in the creation of other objects. You can also reference its individual components with calls such as $g.X() or $g.Y().</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+    <li><i>color</i> (string) - A value indicating the color of the point ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>size</i> (int) - The size of the point, default is 2</li>
+    <li><i>face</i> (string) - The face of the point, defaults to "circle". Options are: cross, circle, square, plus, diamond, triangleUp, 
+		triangleDown, triangleLeft, triangleRight</li>
+	<li><i>label</i> (string) - Attaches a text label to the point, ASCIIMath can be used.</li>
+	<li><i>fontsize</i> (integer) - Affects the font size of the label text.</li>
+	<li><i>fontcolor</i> (string) - The color for the label text</li>
+	<li><i>trace</i> (boolean) - If set to true, the glider will leave a trail of points on the board as it is moved. The trace points
+		can be erased by pressing the 'o' button on the navigation panel.</li>
+	<li><i>answerbox</i> [$thisq, (optional) partNumber] - Places the value the a slider in an answerbox. This will look like: [$thisq] or [$thisq, n] for a multipart question
+		where n is the box number to use.</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.X() - the x-coordinate of the point</li>
+	<li>.Y() - the y-coorindate of the point</li>
+  </ul>
+ <p>Note: For easier grading you can either set question type to N-Tuple, or use the function jsx_getCoords() to help read the coordinates from the answerbox.</p>
+   <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('geometry', ['pan' => false])
+$c = jsxCircle($board, [[0, 0], 2], ['visible' => false])
+$p = jsxGlider($board, [[0, -2], $c], ['label'=>"A", 'color' => 'blue', 'trace' => true]) 
+  </pre>
+
+  <!-- addFunction -->
+  <h2><a style="color:blue" name="jsxFunction">jsxFunction($board, $f, <i>[$options]</i>)</a></h2>
+  <p>Adds the graph of a function to a jsx $board, which is a variable that must be returned from jsxBoard(). $f is the function to graph
+	written as a string using common calculator notation. The return is a variable which is a string object reference to the function, which
+	can be used in other parts of the construction.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+    <li><i>inputvariable</i> (string) - The variable name that your function will take as its input, defaults to <i>x</i></li>
+    <li><i>domain</i> [(float|string) lower, (float|string) upper] sets the bounds for the input of the function. Enter a numerical value 
+		for a static bound, or pass a reference to another object, such as a point or a slider to have a dynamic bound.</li>
+    <li><i>color</i> (string) - A value indicating the color of the curve ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the function graph between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the curve. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>label</i> (string) - Attaches a text label to the curve, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>visible</i> (boolean) - Makes the curve visible or invisible, useful to made a hidden path for a glider</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+   <h4>Example 1</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular', ['zoom' => false, 'pan' => false])
+$a = jsxSlider($board, [-3, 3, 0.1, 1], ['decimals' => 1])
+$f = jsxFunction($board, "sin($a*x)")
+  </pre>
+   <h4>Example 2</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular', ['zoom' => false, 'pan' => false])
+$a = jsxSlider($board, [-3, 3, 0.1, 1])
+$ops = ['domain' => [$a, 10]]
+$f = jsxFunction($board, "sin(x)", $ops)
+  </pre>
+   <h4>Example 3</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$l = jsxLine($board, [[0, 0], [1, 0]], [ 'visible' => false ])
+$p = jsxGlider($board, [[-2, 0], $l])
+$q = jsxGlider($board, [[2, 0], $l])
+$f = jsxFunction($board, "-(x-$p.X())(x-$q.X())")
+</pre>
+
+  <!-- addParametric -->
+  <h2><a style="color:blue" name="jsxParametric">jsxParametric($board, [$x, $y], <i>[$options]</i>)</a></h2>
+  <p>Adds a parametric curve to a jsx $board created by jsxBoard(). $x and $y are strings that represent functions expressed
+	in common calculator syntax and are of the variable <i>t</i> by default.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+    <li><i>inputvariable</i> (string) - Changes the variable name that your x-y functions will take as input, defaults to <i>t</i>.</li>
+    <li><i>domain</i> [(float|string) lower, (float|string) upper] - Sets the bounds for the independed variable of the functions. 
+		Enter a numerical value for a static bound, or a reference to another jsx object such as a slider to have a dynamic bound.</li>
+    <li><i>color</i> (string) - A value indicating the color of the curve ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the graph between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the curve. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>label</i> (string) - Attaches a text label to the curve, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>visible</i> (boolean) - Makes the curve visible or invisible, useful to made a hidden path for a glider</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+  <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$d = jsxSlider($board, [-3.14, 3.14, 0.01], ['decimals' => 2])
+$curve = jsxParametric($board, ["3sin(4t + $d)", "3sin(5t)"])
+  </pre>
+
+  <!-- addPolar -->
+  <h2><a style="color:blue" name="jsxPolar">jsxPolar($board, $rule, <i>[$options]</i>)</a></h2>
+  <p>Adds a polar curve to an existing $board which is a variable returned from jsxBoard(). The variable <i>$rule</i> contains
+	the function that needs to be drawn. It is expected to be a function of <i>t</i>, but this can be modified if needed. The return of
+	this function is a reference to the curve that can be used in other object constructions.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+    <li><i>inputvariable</i> (string) - Changes variable JS will expect as the input variable for the polar function, the default is <i>t</i>.</li>
+    <li><i>domain</i> [(float|string) lower, (float|string) upper] - Sets the domain restriction for the indpendent variable <i>t</i>. 
+		This can be a number for a static bound, or a string with a refrence to another jsx object dynamic bound.</li>
+	<li><i>color</i> (string) - A value indicating the color of the curve ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the graph between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the curve. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>label</i> (string) - Attaches a text label to the curve, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>visible</i> (boolean) - Makes the curve visible or invisible, useful to made a hidden path for a glider</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+  <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$ops = ['size' => [400, 400], 'r' => [7,1], 'theta' => ['pi',6], 'pan' => false]
+$board = jsxBoard('polar', $ops)
+$a = jsxSlider($board, [0.1, 8, 0.1, 1], ['decimals' => 1])
+$graph = jsxPolar($board, "t/3 * cos(t)", [ 'domain' => [0, "$a * pi"]])
+  </pre>
+
+  <!-- Circle -->
+  <h2><a style="color:blue" name="jsxCircle">jsxCircle($board, [$paramenters], <i>[$options]</i>)</a></h2>
+  <p>Adds a circle to an existing $board created by a call to jsxBoard(). The parameters can be set in differnet ways. You can call
+	with [[$x, $y], $r], which would create a circle centered at [$x, $y] and radius $r. The point can be a reference to a jsx point
+	that was previously created or a new point. If you send a new point, the center of the circle will be static, but if you send a 
+	reference it will be dynamic. The same is true of the radius, if you use a reference to another jsx object it will be a dynamic
+	radius.
+	Another way to create a circle is to call with [[$h, $k], [$x, $y]] which will create a circle that has a center located at
+	($h, $k), and passes through the point ($x, $y). Finally, you can call with an array of three points which will create a circle through those
+	three points.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+	<li><i>color</i> (string) - A value indicating the color of the circle ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the circle between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the circle. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>fillcolor</i> (string) - The color to fill the circle with</li>
+	<li><i>fillopacity</i> (float) - A value from 0 (invisible) to 1 (opaque) indicating how translucent the circle fill is.</i>
+	<li><i>label</i> (string) - Attaches a text label to the circle, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>visible</i> (boolean) - Makes the circle visible or invisible, useful to made a hidden path for a glider</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.getRadius() - the radius of the circle</li>
+	<li>.center.X() - the x-coordinate of the center</li>
+	<li>.center.Y() - the y-coordinate of the center</li>
+  </ul>
+  <p>
+    $ref is an optional variable that will give a reference to this object, so the JavaScript object can be referenced via circ_$label_$ref where $label is the label of the board that the circle lives in.
+  </p>
+  <h4>Example 1</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$a = jsxSlider($board, [0, 3, 0.1, 1], ['decimals' => 1])
+$p = jsxPoint($board, [0, 0])
+$circ = jsxCircle($board, [$p, $a], ['color' => 'blue'])
+  </pre>
+  <h4>Example 2</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$a = jsxPoint($board, [0, 0], ['color' => 'orangered'])
+$b = jsxPoint($board, [-2, -2], ['color' => 'orangered'])
+$ops = ['color' => 'orange', 'dash' => 3, 'fillcolor' => 'orange', 'fillopacity' => 0.3]
+$circ = jsxCircle($board, [$a, $b], $ops)
+  </pre>
+  <h4>Example 3</h4>
+  <pre>  
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$a = jsxPoint($board, [1, 1])
+$b = jsxPoint($board, [-2, -2])
+$circ = jsxCircle($board, [$a, $b, [-3, 2]], ['color' => 'blue'])
+</pre>
+  <!-- Polygon -->
+  <h2><a style="color:blue" name="jsxPolygon">jsxPolygon($board [$pointlist], <i>[$options]</i>)</a></h2>
+  <p>Adds a polygon to a jsx $board object created by a call to jsxBoard(). The input to this function is an array of points
+	describing the vertices of the polygon. If you use points defined as arrays of float values, these vertices will be static,
+	but if you sent jsxPoints, or references to other objects, the vertices will be dynamic. The return of this function is a
+	reference variable to this object that can be used in the creation of other objects.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+	<li><i>color</i> (string) - A value indicating the color of the border of the polygon ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the border of the polygon between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the polygon's border. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>fillcolor</i> (string) - The color to fill the polygon with</li>
+	<li><i>fillopacity</i> (float) - A value from 0 (invisible) to 1 (opaque) indicating how translucent the polygon fill is.</i>
+	<li><i>label</i> (string) - Attaches a text label to the polygon, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>visible</i> (boolean) - Makes the polygon visible or invisible, useful to made a hidden path for a glider</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+  <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$p = jsxPoint($board, [-1, 3])
+$ops = ['fillcolor' => '#00FF00']
+$poly = jsxPolygon($board, [[1, 2], $p, [-3, 2]], $ops)
+  </pre>
+
+  <!-- Line -->
+  <h2><a style="color:blue" name="jsxLine">jsxLine($board, [[$x1, $y1], [$x2, $y2]], <i>[$options]</i>)</a></h2>
+  <p>Adds a line to a jsx $board, which is a variable returned from jsxBoard. The input to this function two points that the line
+	line is passing through. This can be an array of float values that will produce a static point, or it can be a reference to a
+	jsx point of some sort to make a dynamic line. The return is a reference to the line that can be used in other jsx object
+	creations.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+	<li><i>color</i> (string) - A value indicating the color of the line ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the line between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the line. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>label</i> (string) - Attaches a text label to the line, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>visible</i> (boolean) - Makes the line visible or invisible, useful to made a hidden path for a glider</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.getSlope() - returns the slope of the line</li>
+	<li>.point1.X(), .point1.Y() - the coordinates of the first point</li>
+	<li>.point2.X(), .point2.Y() - the coordinates of the second point</li>
+  </ul>
+
+  <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('geometry')
+$c = jsxCircle($board, [[0, 0], 2.5])
+$p = jsxGlider($board, [[2.5, 0], $c], ['label' => 'A', 'fontcolor' => 'blue'])
+$line = jsxLine($board, [[-4, 0], $p])
+  </pre>
+
+  <!-- addSegment -->
+  <h2><a style="color:blue" name="jsxSegment">jsxSegment($board, [[$x1, $y1], [$x2, $y2]], <i>[$options]</i>)</a></h2>
+  <p>Adds a segment to a jsx $board, which is a variable returned from jsxBoard. A segment is defined a the portion of a line that 
+	begins at [$x1, $y1] and ends at [$x2, $y2]. Each point can either be an array of float values - which will produce a static point, 
+	or it can be a reference to a jsx point of some sort to make a segment that can be manipulated. The return is a reference to the 
+	segment that can be used in other jsx object creations.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+	<li><i>color</i> (string) - A value indicating the color of the segemnt ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the segment between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the segment. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>label</i> (string) - Attaches a text label to the segment, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>visible</i> (boolean) - Makes the segment visible or invisible, useful to made a hidden path for a glider</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+	<p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.getSlope() - returns the slope of the line</li>
+	<li>.point1.X(), .point1.Y() - the coordinates of the first point</li>
+	<li>.point2.X(), .point2.Y() - the coordinates of the second point</li>
+  </ul>
+  <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('geometry')
+$a = jsxPoint($board, [-4, -3], ['label' => 'A'])
+$b = jsxPoint($board, [-2, 4], ['label' => 'B'])
+$c = jsxPoint($board, [1, 0], ['label' => 'C'])
+$s0 = jsxSegment($board, [$a, $b])
+$s1 = jsxSegment($board, [$b, $c])
+$s2 = jsxSegment($board, [$c, $a])
+  </pre>
+
+ <!-- Ray -->
+  <h2><a style="color:blue" name="jsxRay">jsxRay($board, [[$x1, $y1], [$x2, $y2]], <i>[$options]</i>)</a></h2>
+  <p>Adds a ray to a jsx $board, which is a variable returned from jsxBoard. A ray is defined a the portion of a line that 
+	begins at [$x1, $y1] and extentds through [$x2, $y2]. An arrow is drawn by default at the end of the ray indicating its diretction.
+	This can be turned off by setting lastArrow to false in an attribute setting. Each point can either be an array of float values - 
+	which will produce a static	point, or it can be a reference to a jsx point of some sort to make a ray that can be manipulated. 
+	The return is a reference to the ray that can be used in other jsx object creations.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+	<li><i>color</i> (string) - A value indicating the color of the ray ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the ray between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the ray. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>label</i> (string) - Attaches a text label to the ray, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>visible</i> (boolean) - Makes the ray visible or invisible, useful to made a hidden path for a glider</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+   </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.getSlope() - returns the slope of the line</li>
+	<li>.point1.X(), .point1.Y() - the coordinates of the first point</li>
+	<li>.point2.X(), .point2.Y() - the coordinates of the second point</li>
+  </ul>   
+ <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('geometry')
+$a = jsxPoint($board, [0, 0])
+$r1 = jsxSegment($board, [$a, [4, 0]])
+$r2 = jsxSegment($board, [$a, [-4, 0]])
+  </pre>
+  </pre>
+
+  <!-- addArrow -->
+  <h2><a style="color:blue" name="jsxVector">jsxVector($board, [[$x1, $y1], [[$x2, $y2]] or [$mag, $dir], <i>[$options]</i>)</a></h2>
+  <p>Createa a vector on a jsx $board, which is a variable returned by jsxBoard. You can call the function with the x and y coordinates
+	of an initial and terminal point of a vector, or you can provide the magnitude and direction of a vector in standard position. If
+	you need the initial point in the second example to be something other than [0, 0], you can set the <i>offset</i> parameter with an
+	array of points to place the start of the vector. The return of the function is a reference to the vector object that can be used
+	in other jsx object constructions.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+	<li><i>color</i> (string) - A value indicating the color of the vector ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the vector between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the vector. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>label</i> (string) - Attaches a text label to the vector, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.getSlope() - returns the slope of the line</li>
+	<li>.point1.X(), .point1.Y() - the coordinates of the first point</li>
+	<li>.point2.X(), .point2.Y() - the coordinates of the second point</li>
+  </ul>
+  <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('geometry')
+$a = jsxSlider($board, [0, 1, 0.01, 0], ['decimals' => 2])
+$v = jsxVector($board, [3, "$a * 2 * pi"])
+  </pre>
+
+
+  <!-- addTangent -->
+  <h2><a style="color:blue" name="jsxTangent">jsxTangent($board, $glider, <i>[$options]</i>)</a></h2>
+  <p>Adds a tangent line to an object (circle, function, etc.). These can only be placed on a glider that exists on the object. 
+	$board should be a variable returned from jsxBoard().</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+  	<li><i>color</i> (string) - A value indicating the color of the vector ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+    <li><i>width</i> (int) - The width of the vector between 1 and 9, default is 2</li>
+    <li><i>dash</i> (int) - Affects the draw pattern of the vector. Set to 1 through 6 to get different dashes, no dashing by default.</li>
+	<li><i>label</i> (string) - Attaches a text label to the vector, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+    <li><i>visible</i> = (boolean) - Can be used to show or hide the tangent</li>
+  </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.getSlope() - returns the slope of the line</li>
+  </ul>
+  <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$f = jsxFunction($board, "sec(x)")
+$p = jsxGlider($board, [[0, 0], $f])
+$ops = ['label' => "'`m`&nbsp;=&nbsp;' + this.getSlope().toFixed(2)"]
+$tangent = jsxTangent($board, $p, $ops)
+
+  </pre>
+
+  <!-- Angle -->
+  <h2><a style="color:blue" name="jsxAngle">jsxAngle($board, [$p1, $p2, $p3], <i>[$options]</i>)</a></h2>
+  <p>Creates an angle on a jsx $board, which is a variable created by jsxBoard(). This will only create the angle measure itself,
+	and will not create lines to surround the angle. $p1, $p2, and $p3 are the three points that define the angle, $p1 being the
+	center point. The order of $p1 and $p3 is important as one direction will make an internal angle and the other order will
+	create an external angle. Right angles are marked with a square.</p>
+  <p>$ops is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+	<li><i>color</i> (string) - A value indicating the color of the border of the angle ('red', 'green', etc.) an RGB/RGBA value encoded in hexadecimal, or
+		a value such as rbga(45, 45, 45, 28)</li>
+	<li><i>fillcolor</i> (string) - The color to fill the angle with</li>
+	<li><i>fillopacity</i> (float) - A value from 0 (invisible) to 1 (opaque) indicating how translucent the angle fill is.</i>
+	<li><i>label</i> (string) - Attaches a text label to the circle, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.Value() - the measure of the angle in radians</li>
+  </ul>
+  <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('geometry')
+$p1 = jsxPoint($board, [4, 0])
+$p2 = jsxPoint($board, [0, 0], ['visible' => false])
+$p3 = jsxPoint($board, [-1, 4])
+$v1 = jsxVector($board, [$p2, $p1])
+$v2 = jsxVector($board, [$p2, $p3])
+$ops = ['label' => "'&alpha; = ' + (this.Value() * 180 / pi).toFixed(0) + '&deg;'"]
+$angle = jsxAngle($board, [$p1, $p2, $p3], $ops)
+  </pre>
+
+  <!-- addText -->
+  <h2><a style="color:blue" name="jsxText">jsxText($board, [[$x, $y], $text], <i>[$options]</i>)</a></h2>
+  <p>Enables the ability to add a text box to a jsx $board. This is the same construct as an object's label, but it allows
+	placement anywhere on the board, and doesn't have to be anchored to an object. Can be used to display aspects of objects.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+    <li><i>anchor</i> (point) - The position of the text object on screen. This needs to be a jsxPoint that was previously
+		declared.</li>r
+   	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+  <h4>Example</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('geometry')
+$p1 = jsxPoint($board, [4, 0])
+$text = jsxText($board, [[-4.5, 4.5], "'`x = `' + $p1.X().toFixed(2)"])
+  </pre>
+
+  <!-- jsxIntegral -->
+  <h2><a style="color:blue" name="jsxIntegral">jsxIntegral($board, [[$x1, $x2], $f], <i>[$options]</i>)</a></h2>
+  <p>Creates an integral object, which allows to shade the area trapped between a curve and the x-axis. [$x1, $x2] 
+	is an array of a starting x-value and ending x-value for the integral, these can be float values or references 
+	to other jsx objects. If float values are provided, then a static integral will be created, if jsx objects are 
+	provided, then the integral will be interactable. $param[1] is a function created by jsx to find the area under. 
+	The return is a reference that can be used in other object creation.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+	<li><i>color</i> (string) - A value indicating the color of the shaded redgion of the integral ('red', 'green', etc.) 
+		an RGB/RGBA value encoded in hexadecimal, or a value such as rbga(45, 45, 45, 28)</li>
+	<li><i>fillopacity</i> (float) - A value from 0 (invisible) to 1 (opaque) indicating how translucent the angle fill is.</i>
+   	<li><i>label</i> (string) - Attaches a text label to the integral, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.Value() - the value of the integral</li>
+  </ul>
+  <h4>Example 1</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$a = jsxSlider($board, [-pi, pi, 0.1], ['decimals' => 1])
+$f = jsxFunction($board, "sin(x)")
+$integral = jsxIntegral($board, [[$a, pi], $f])
+  </pre>
+  <h4>Example 2</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$k = jsxSlider($board, [0, 3, 0.1, 1], ['decimals' => 1])
+$axis = jsxLine($board, [[0, 0], [1, 0]], ['visible' => false])
+$a = jsxGlider($board, [[-1, 0], $axis])
+$b = jsxGlider($board, [[1, 0], $axis])
+$f = jsxFunction($board, "$k * sin(x)")
+$integral = jsxIntegral($board, [["$a.X()", "$b.X()"], $f], ['label' => "'`int = `' + this.Value().toFixed(2)"])
+  </pre>
+  
+  <!-- jsxRiemannSum -->
+  <h2><a style="color:blue" name="jsxRiemannSum">jsxRiemannSum($board, [[$a, $b, $n], $f or <i>[$f, $g]</i>, <i>[$options]</i>)</a></h2>
+  <p>Creates a Riemann sum trapped between a function and the x-axis, or between two different functions. The parameters 
+	expected are passed in an array and are: an array containing the lower endpoint and upper endpoint of the interval and
+	the number of rectangles to use. Each of these items can be numeric that will make them static. You can also use 
+	references to other jsx objects in order to make them dynamic. The second parameter can be a single function in order to
+	create rectangles between the x-axis and the function, or an array of functions which will draw the rectanges between the 
+	functions. The return is an object reference that can be used in the creation of other jsx objects.</p>
+  <p><i>$options</i> is an associative array containing name/value pairs for the options. The options are:</p>
+  <ul>
+	<li><i>type</i> (string) - The type of rectangles to use in the approximation. Options are: left, right, middle,
+		lower, upper, random, simpson, or trapezoidal. Default value is left. Note that 'simpson' does not draw approximating
+		quadratics.</li>
+	<li><i>inputvariable</i> (string) - The variable used within your function, default is 'x'.</li>
+	<li><i>color</i> (string) - A value indicating the border color of the rectangles ('red', 'green', etc.) 
+		an RGB/RGBA value encoded in hexadecimal, or a value such as rbga(45, 45, 45, 28)</li>
+	<li><i>fillopacity</i> (float) - A value from 0 (invisible) to 1 (opaque) indicating how translucent the rectangle fill is.</i>
+	<li><i>fillcolor</i> (string) - The color to fill in the rectangles with, defaults to $color.
+   	<li><i>label</i> (string) - Attaches a text label to the rectangles, ASCIIMath can be used.</li>
+	<li><i>fontcolor</i> (string) - The color of the label</li>
+	<li><i>fontsize</i> (int) - The size of the label text</li>
+	<li><i>attributes</i> (json) - A json object encoded as a string that contains the value of any additional attributes you can modify from the jsxgraph API.</li>
+  </ul>
+    <p>Additional JavaScript functions that can be used in JSX constructions and labels:</p>
+  <ul>
+	<li>.Value() - the sum of the rectangles</li>
+  </ul>
+  <h4>Example 1</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$n = jsxSlider($board, [1, 100, 1, 4])
+$f = jsxFunction($board, "4*sin(x)")
+$sum = jsxRiemannSum($board, [[-pi, pi, $n], $f], ['type' => 'middle'])
+  </pre>
+  <h4>Example 2</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$n = jsxSlider($board, [1, 10, 1, 4])
+$axis = jsxLine($board, [[0, 0], [1, 0]], ['visible' => false])
+$a = jsxGlider($board, [[-1, 0], $axis])
+$b = jsxGlider($board, [[1, 0], $axis])
+$f = jsxFunction($board, "2")
+$g = jsxFunction($board, "x")
+$sum = jsxRiemannSum($board, [["$a.X()", "$b.X()", $n], [$f, $g]])
+  </pre>  
+  
+  <h2><a style="color:blue" name="jsxSuspendUpdate">jsxSuspendUpdate($board)</a></h2>
+  <p>Temporarily pauses all updates to a board object so that a lot of objects can be drawn more quickly. This is useful
+	if you have a lot of objects to draw initially, like a set of points for instance.</p>
+  
+  <h2><a style="color:blue" name="jsxUnsuspendUpdate">jsxUnsuspendUpdate($board)</a></h2>
+  <p>Unpauses updates to a board object so that objects will become interactive again.</p>
+  
+  <h2><a style="color:blue" name="jsx_getCoords">jsx_getCoords(string))</a></h2>
+  <p>Takes a string that depicts a point and returns the x and y coordinates contained within, useful for grading questions
+	based on the location of a jsx point.</p>
+	
+  <h2><a style="color:blue" name="jsx_getXCoord">jsx_getXCoord(string))</a></h2>
+  <p>Takes a string that depicts a point and returns only the x coordinate of the point, useful for grading questions
+	based on the location of a jsx point.</p>
+	
+  <h2><a style="color:blue" name="jsx_getYCoord">jsx_getYCoord(string))</a></h2>
+  <p>Takes a string that depicts a point and returns only the y coordinate of the point, useful for grading questions
+	based on the location of a jsx point.</p>
+
+<h2>Advanced Examples</h2>
+<p>This example demonstrates how to make dynamic aspects from items that may not seem obvious. JSX Graph supports making all items
+	dynamic, but it isn't always useful. However, this library gives you the ability to take advantage of those advanced constructs
+	but you must resort to more complex notation. For example here, I have tied the opacity attribute of a polygon to a slider, allowing
+	me to change the opacity dynamically. This had to be accomplished by creating a wrapper function - which is a common construct in
+	JSX dynamic objects - within a json parameter. Notice that within the construct I can call $a which is a reference to the slider, 
+	but I have to call $a.Value() in order to get the value of the slider. This is the procedure in JSX graph, but in this library, I
+	made it so you don't have to use the .Value() function to get the value of a slider for simplicity.</p>
+<h4>Example 1</h4>
+<pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$a = jsxSlider($board, [0, 1, 0.01], ['decimals' => 2])
+$poly = jsxPolygon($board, [[1, 2], [-1, 3], [-3, 2]], ['attributes' => " { fillOpacity: function() { return $a.Value(); } } "])
+$g = jsxGlider($board, [[0, 0], $poly])
+</pre>
+<p>The next example demonstrates how you can control the positioning of labels if the default position is not preferred. The
+	easiest option is to use a text object for the label, rather than the objects' label because the positioning can easily
+	be controlled through the anchor attribute.</p>
+<h4>Example 2</h4>
+<pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard('rectangular')
+$a = jsxPoint($board, [-3, -2])
+$b = jsxPoint($board, [4, 1])
+$midpoint = jsxPoint($board, ["($a.X() + $b.X()) / 2", "($a.Y() + $b.Y()) / 2"], ['visible' => false])
+$line = jsxLine($board, [$a, $b])
+$label = jsxText($board, [[0,0], "'slope = ' + $line.getSlope().toFixed(2)"], ['anchor' => "$midpoint"])
+</pre>
+
+</body>
+</html>

--- a/assessment/libs/jsxgraph.html
+++ b/assessment/libs/jsxgraph.html
@@ -20,7 +20,7 @@
 <body>
   <h1>jsxgraph Macro Library</h1>
   <p>JSXGraph Integration functions - Version 1.1</br>by David Flenner</p><p>Written: October 14th, 2020</p><p>Last Updated: January 30th, 2021</p>
-  <p style="font-size:5%"><i>Adapted from JSXG library written by Grant Sander</i></p>
+  <p style="font-size:12px"><i>Adapted from JSXG library written by Grant Sander</i></p>
   <hr>
   <h2>Introduction</h2>
   <p>This library provides an interface to the mathematics graphics library <a href="http://jsxgraph.uni-bayreuth.de/wp/index.html">JSXGraph</a> 
@@ -69,7 +69,7 @@
 	question using it, please tag the question with #jsx in the name of the question so its easy for everyone to be able to find these great
 	interactive questions!
 </p>
-   <h3>Known Bugs:</h3>
+   <h3>Notes:</h3>
    <ul>
 	 <li>When the question type is set to <i>conditional</i> using the old interface, the board can revert to a smaller size after the submit button is pressed. This can 
 		be avoided if the question text is longer than the board display. That prevents the board from being re-drawn in a smaller size.</li>

--- a/assessment/libs/jsxgraph.html
+++ b/assessment/libs/jsxgraph.html
@@ -19,8 +19,8 @@
 </head>
 <body>
   <h1>jsxgraph Macro Library</h1>
-  <p>JSXGraph Integration functions - Version 1.0</br>by David Flenner</p><p>October 14th, 2020</p>
-  <p><i>Adapted from JSXG library written by Grant Sander</i></p>
+  <p>JSXGraph Integration functions - Version 1.1</br>by David Flenner</p><p>Written: October 14th, 2020</p><p>Last Updated: January 30th, 2021</p>
+  <p style="font-size:5%"><i>Adapted from JSXG library written by Grant Sander</i></p>
   <hr>
   <h2>Introduction</h2>
   <p>This library provides an interface to the mathematics graphics library <a href="http://jsxgraph.uni-bayreuth.de/wp/index.html">JSXGraph</a> 
@@ -48,6 +48,12 @@
 	customize the label, you can change the 'fontcolor' and the 'fontsize' through $options. All labels	support ASCII math, and that can 
 	be enabled by surrounding your text with ``:</p>
 	<pre>$p = jsxPoint($board, [1, 2], ['label' => '`pi`'])</pre>
+	<p>Alternatively, you can use rendering hints to make your labels display in ASCII math, just pass your label as an array with the first
+	element containing your label, and the next element containing the word: 'display'. This will wrap your label in back-ticks for you. 
+	Another rendering hint you can use is 'makepretty', this will attemp to clean up things like 1*x^2 = x^2 or 0*x+2 = 2 in your functions
+	for nicer display. Test this extensively with your function as the regular expressions cleaning these can be buggy with different kinds
+	of functions, but should work fine with polynomials, exponentials, and basic elementary functions.</p>
+	<pre>$a = jsxFunction($board, "x+$a", ['label' => ["'y = x+' + $a.Value()", 'makepretty', 'display']])</pre>
 	<p>If you need to express the deriviative of a function, it is best to write f prime (x) in your ASCII Math because writing f'(x) can 
 	confuse the system since ' is used to start and end a string</p>
 	<p>You can also	create dynamic labels by using references to jsx objects in conjunction with javascript. To reference an object 
@@ -67,7 +73,6 @@
    <ul>
 	 <li>When the question type is set to <i>conditional</i> using the old interface, the board can revert to a smaller size after the submit button is pressed. This can 
 		be avoided if the question text is longer than the board display. That prevents the board from being re-drawn in a smaller size.</li>
-	 <li>ticksdistance does not appear to be working with rectangular boards</li>
    </ul>
 
 <h3>Functions in this Library:</h3>
@@ -123,6 +128,10 @@
     <li><i>axislabel</i> [(string) xLabel, (string) yLabel] - adds labels to the axes, ASCIIMath can be used</li>
     <li><i>ticksdistance</i> [(float) ticksDistanceX, (float) ticksDistanceY] sets the distance between each major tick on the axes</li>
     <li><i>minorticks</i> [(int) minorTicksX, (int) minorTicksY] sets the number of minor ticks between each major tick on the axes</li>
+	<li><i>showlabels</i> [(boolean) showLabelsX, (boolean) showLabelsY] - turns on or off the axis grid labels</li>
+	<li><i>gridheight</i> [(int) gridHeightX, (int) gridHeightY] - set the length of the major grid lines in the x and y direction. By default
+		these are set to -1, which draws grid lines that span the entire board.</li>
+	<li><i>minortickheight</i> [(int) minorTickHeightX, (int) minorTickHeightY] - set the length of the minor ticks</li>
   </ul>
   <p>The following options are used with polar boards:</p>
   <ul>
@@ -193,6 +202,13 @@ loadlibrary("jsxgraph")
 $board = jsxBoard("rectangular")
 $ops = ['answerbox' => [$thisq], 'position' => [[-4, -4], [1, -4]], 'color' => '#935218', 'decimals' => 1, 'name' => "a", 'fontsize' => 20, 'attributes' => '{ face: "cross" }']
 $a = jsxSlider($board, [-15, 10, 0.1, 8], $ops)
+  </pre>
+   <h4>Example 3</h4>
+  <pre>
+loadlibrary("jsxgraph")
+$board = jsxBoard("rectangular")
+$a = jsxSlider($board, [-10, 10, 0.1], ['label' => "'a =' + this.Value().toFixed(1)",  'decimals' => 1])
+$f = jsxFunction($board, "($a) * (x-3)*(x+1)")
   </pre>
 
   <!-- jsxPoint -->

--- a/assessment/libs/jsxgraph.php
+++ b/assessment/libs/jsxgraph.php
@@ -1,0 +1,2266 @@
+<?php
+// JSXGraph interface for iMathias 2020 version 1.0
+// by David Flenner
+//
+// adapted from JSXG.php by Grant Sandler
+
+
+// https://www.onemathematicalcat.org/JSXGraphDocs/JSXGraphDocs.htm
+
+// - Points: moveTo for animation?
+// - Buttons, checkboxes?
+// - Functions that allows the execution of javascript statements from the php code
+// - Angle value should be able to be put in an answerbox
+
+// - Mass create points
+// - Can I create suspendUpdate and unsuspendUpdate functions from the PHP?
+
+// - Allow user to indicate which function should be placed in the answerbox
+// - Is it possible to have a function that just takes a string input of javascript code to insert?
+// - What about a function to execute JessieCode?
+// - Can I attach a picture to a problem and reference it within the JSX as an image object?
+
+global $allowedmacros;
+
+$allowedmacros[] = "jsxBoard";
+$allowedmacros[] = "jsxSlider";
+$allowedmacros[] = "jsxPoint";
+$allowedmacros[] = "jsxGlider";
+$allowedmacros[] = "jsxFunction";
+$allowedmacros[] = "jsxParametric";
+$allowedmacros[] = "jsxPolar";
+$allowedmacros[] = "jsxText";
+$allowedmacros[] = "jsxCircle";
+$allowedmacros[] = "jsxLine";
+$allowedmacros[] = "jsxSegment";
+$allowedmacros[] = "jsxRay";
+$allowedmacros[] = "jsxVector";
+$allowedmacros[] = "jsxAngle";
+$allowedmacros[] = "jsxPolygon";
+$allowedmacros[] = "jsxTangent";
+$allowedmacros[] = "jsxIntegral";
+$allowedmacros[] = "jsxRiemannSum";
+$allowedmacros[] = "jsx_getXCoord";
+$allowedmacros[] = "jsx_getYCoord";
+$allowedmacros[] = "jsx_getCoords";
+$allowedmacros[] = "jsxSuspendUpdate";
+$allowedmacros[] = "jsxUnsuspendUpdate";
+
+
+// next in line:
+// -- integral
+
+
+function jsx_getlibrarylink() {
+	return "//cdnjs.cloudflare.com/ajax/libs/jsxgraph/1.1.0/jsxgraphcore.js";
+}
+
+function jsx_idlen() {
+	return 13;
+}
+
+function jsx_validobjects() {
+	$ob1 = ['point', 'slider', 'function', 'circle', 'polygon'];
+	$ob2 = ['line', 'segment', 'ray', 'vector', 'text', 'angle'];
+	$ob3 = ['glider', 'tangent', 'polar', 'parametric', 'integral'];
+	$ob4 = ['riemannsum'];
+	return array_merge($ob1, $ob2, $ob3, $ob4);
+}
+
+###########################################################################
+##
+## Basic structure for an object builder
+##
+###########################################################################
+
+function jsxObject (&$board, $param, $ops=array()) {
+
+	$id = "object_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+
+	if (!$inputerror) {
+
+		// Set default values
+		
+
+		// Begin object creation
+
+		$out = "var {$id} = board_{$boardID}.create('object', [";
+		
+
+
+		// Set attributes 
+		
+		$out .= "{
+
+		})";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "error message";
+	}
+}
+
+
+
+###########################################################################
+##
+## The following items are basic elemental items in that they contain basic
+##   aspects that can be placed in an answerbox for grading.
+##
+## The elemental objects are:
+##    Points, Sliders, Angles, and any kind of derivative point such as
+##      Gliders (PointOnObject), Midpoints, Intersections, etc.
+##
+###########################################################################
+
+########################################################################################
+##
+##  Adds a slider to a jsx board, which allows manipulation of the value of a variable.
+##
+##		$param = [min, max, step]
+##
+##  Position is automatically determined unless coordinates are specified, the position
+##		will not change with zooms and pans.
+##
+##  Parameters may not be other jsx objects or properties.
+##
+########################################################################################
+
+function jsxSlider (&$board, $param, $ops=array()) {
+
+	$id = "slider_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$nSliders = jsx_getslidercount($board) + 1;
+
+	// $param - [min, max, step, default]
+	
+	if (!is_array($param) || !(count($param) == 3 || count($param) == 4)) {
+		echo "Eek! jsxSlider requires an array with three or four inputs: [min, max, step, <i>defaultval</i>]";
+	} else {
+
+		$min = is_numeric($param[0]) ? $param[0] : 0;
+		$max = is_numeric($param[1]) ? $param[1] : 10;
+		$step = is_numeric($param[2]) ? $param[2] : 1;
+		$defaultval = $param[3] !== null ? $param[3] : ($min + $max) / 2;
+		
+		// Parameters:
+		//  label, color, default value, showLabel, LabelSize, decimals, position,
+		//  answerbox
+	
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$color = $ops['color'] !== null ? $ops['color'] : 'purple';
+		$showlabel = $ops['showlabel'] !== null ? jsx_getbool($ops['showlabel']) : 'true';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+		$name = $ops['name'] !== null ? $ops['name'] : '';
+		$decimals = $ops['decimals'] !== null ? $ops['decimals'] : 0;
+		
+		if ($ops['position'] === null) {
+			
+			$relpos = true;
+			$x1 = 0.05;
+			$y1 = 0.05 * $nSliders;
+			$x2 = 0.25;
+			$y2 = 0.05 * $nSliders;
+			
+		} else {
+			
+			$relpos = false;
+			$x1 = $ops['position'][0][0] !== null ? $ops['position'][0][0] : 1;
+			$y1 = $ops['position'][0][1] !== null ? $ops['position'][0][1] : 1 * $nSliders;
+			$x2 = $ops['position'][1][0] !== null ? $ops['position'][1][0] : 5;
+			$y2 = $ops['position'][1][1] !== null ? $ops['position'][1][1] : 1 * $nSliders;
+			
+		}
+		
+		// Create the slider
+		$out = "var {$id} = board_{$boardID}.create('slider', [";
+		
+		// Set the positioning
+		if ($relpos) {
+			$out .= "[function() { return board_{$boardID}.getBoundingBox()[0] + {$x1} * (board_{$boardID}.getBoundingBox()[2] - board_{$boardID}.getBoundingBox()[0]); }, 
+					  function() { return board_{$boardID}.getBoundingBox()[1] - {$y1} * (board_{$boardID}.getBoundingBox()[1] - board_{$boardID}.getBoundingBox()[3]); }],
+					 [function() { return board_{$boardID}.getBoundingBox()[0] + {$x2} * (board_{$boardID}.getBoundingBox()[2] - board_{$boardID}.getBoundingBox()[0]); }, 
+					  function() { return board_{$boardID}.getBoundingBox()[1] - {$y2} * (board_{$boardID}.getBoundingBox()[1] - board_{$boardID}.getBoundingBox()[3]); }],";
+		} else {
+			$out .= "[{$x1},{$y1}] , [{$x2},{$y2}],";
+		}
+		
+		// Set the parameters
+		$out .= " [{$min},{$defaultval},{$max}]],
+			{
+				snapWidth: {$step},
+				precision: {$decimals},
+				baseline: { fixed: true, highlight: false },
+				ticks: { fixed: true, highlight: false} ,
+				highline: { highlight: false, strokeColor: '{$color}' },
+				strokeColor: '{$color}',
+				name: '{$name}',
+				label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+			})";
+			
+		// Set any remaining paramenters specified by user
+		$out .= $ops['attributes'] !== null ? ".setAttribute( {$ops['attributes']} )" : "";
+			
+		// Now handle the answerbox communication
+
+		if ($ops['answerbox'] !== null) {
+			if (count($ops['answerbox']) == 1) { 
+				$box = $ops['answerbox'][0] - 1;
+			} else {
+				$box = $ops['answerbox'][0] * 1000 + $ops['answerbox'][1];
+			}
+			
+			// Add event listener
+			$out .= ".on('up',function() { $('#qn{$box}, #tc{$box}').val(this.Value().toFixed(8));	});";
+			$out .= jsx_getcolorinterval($boardID, $box, $id, "slider", [$min, $max]); 
+	
+		} else {
+			$out .= ";";
+		}
+
+		$out .= jsx_setlabel($id, $label);
+
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"),0);
+		return $id;
+		
+	}
+
+}
+
+// Creats a point on a jsx board that can be moved around by the user.
+// The point's coordinates can be saved in an answer box for grading.
+
+function jsxPoint(&$board, $param, $ops=array()) {
+	
+	$id = "point_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$out = "";
+	
+	if (is_jsxpoint($param)) {
+		
+		// Parameter: $fixed, $color, $size, $face, $label, $visible
+				
+		$fixed = $ops['fixed'] !== null ? jsx_getbool($ops['fixed']) : 'false';
+		$color = $ops['color'] !== null ? $ops['color'] : 'black';
+		$size = $ops['size'] !== null ? $ops['size'] : 2;
+		$face = $ops['face'] !== null ? $ops['face'] : 'circle';
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+		$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+		$snapSizeX = $ops['xsnapsize'] !== null ? $ops['xsnapsize'] : 1;
+		$snapSizeY = $ops['ysnapsize'] !== null ? $ops['ysnapsize'] : 1;
+		$trace = $ops['trace'] !== null ? jsx_getbool($ops['trace']) : 'false';
+		
+		if (($ops['xsnapsize'] !== null) || ($ops['ysnapsize'] !== null)) {
+			$snapToGrid = 'true';
+		} else {
+			$snapToGrid = 'false';
+		}
+			
+		// Start making the point
+		$out = "var {$id} = board_{$boardID}.create('point', ".jsx_pointToJS($param).",";
+		
+		// Set the attributes
+		
+		$out .= "{
+			highlight: {$fixed},
+			showInfobox: false,
+			fixed: {$fixed},
+			color: '{$color}',
+			size: {$size},
+			face: '{$face}',
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false },
+			name: '',
+			trace: {$trace},
+			visible: {$visible},
+			snapSizeX: {$snapSizeX},
+			snapSizeY: {$snapSizeY},
+			snapToGrid: {$snapToGrid}
+		})";
+		
+		// Set any remaining paramenters specified by user
+		$out .= $ops['attributes'] !== null ? ".setAttribute( {$ops['attributes']} )" : "";
+		
+		// If answerbox option provided, set up box number
+		if ($ops['answerbox'] !== null) {
+			
+			if (count($ops['answerbox']) == 1) { 
+				$box = $ops['answerbox'][0] - 1;
+			} else {
+				$box = $ops['answerbox'][0] * 1000 + $ops['answerbox'][1];
+			}
+
+			$answerfill = "'(' + this.X().toFixed(4) + ',' + this.Y().toFixed(4) + ')'";
+			
+			$out .= ".on('up', function() {	$('#qn{$box}, #tc{$box}').val({$answerfill}); } );";  
+			$out .= jsx_getcolorinterval($boardID, $box, $id, "point");
+				
+		} else {
+			$out .= ";";
+		}     
+		
+		$out .= jsx_setlabel($id, $label);
+		
+	} else {
+		echo "Eek! parameters for a point must include the board to place it on
+			  and the coordinates as an array.<br>";
+	}
+	
+	// Append new output string to the board string
+	$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"),0);
+	return $id;
+	
+}
+
+// Creates a point that can be moved around the plane, but its movement is
+// restricted to a curve. JSX normally called this a 'glider'.
+
+function jsxGlider (&$board, $param, $ops=array()) {
+	
+	$id = "glider_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+	if (!is_array($param) && count($param) != 2) {
+		$inputerror = true;
+	} else if(!is_jsxpoint($param[0]) || !is_jsxobjectref($param[1])) {
+		$inputerror = true;
+	}
+
+	if (!$inputerror) {
+
+		// Set default values
+		$color = $ops['color'] !== null ? $ops['color'] : 'black';
+		$size = $ops['size'] !== null ? $ops['size'] : 2;
+		$face = $ops['face'] !== null ? $ops['face'] : 'circle';
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+		$trace = $ops['trace'] !== null ? jsx_getbool($ops['trace']) : 'false';
+
+		// Begin object creation
+		$out = "var {$id} = board_{$boardID}.create('glider', [";
+		$out .= jsx_valueToJS($param[0][0]).", ";
+		$out .= jsx_valueToJS($param[0][1]).", ";
+		$out .= "{$param[1]}], ";
+
+		// Set attributes 
+		$out .= "{
+            highlight: true,
+            showInfobox: false,
+            fixed: false,
+			trace: {$trace},
+            color: '{$color}',
+            size: {$size},
+            face: '{$face}',
+			name: '',
+            label: { color: '{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+        })";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']})";
+		} 
+		
+		// If answerbox option provided, link the point to the answerbox
+		if ($ops['answerbox'] !== null) {
+			
+			if (count($ops['answerbox']) == 1) {
+				$box = $ops['answerbox'][0] - 1;
+			} else {
+				$box = $ops['answerbox'][0] * 1000 + $ops['answerbox'][1];
+			}
+
+			$answerfill = "'(' + this.X().toFixed(4) + ',' + this.Y().toFixed(4) + ')'";		
+			$out .= ".on('up', function() {	$('#qn{$box}, #tc{$box}').val({$answerfill}); } );";
+					
+			$out .= jsx_getcolorinterval($boardID, $box, $id, "point"); 
+				
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! To attach a point on another object, you must provide a location, and the object.";
+	}
+
+}
+
+
+function jsxCircle(&$board, $param, $ops=array()) {
+	
+	$id = "circle_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$out = "var {$id} = ";
+	$is_error = false;
+
+    // attributes
+    $highlight = $ops['highlight'] !== null ? jsx_getbool($ops['highlight']) : 'false';
+    $fixed = $ops['fixed'] !== null ? jsx_getbool($ops['fixed']) : 'true';
+    $color = $ops['color'] !== null ? $ops['color'] : 'black';
+    $dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+    $width = $ops['width'] !== null ? $ops['width'] : 2;
+	$haslabel = $ops['label'] !== null ? 'true' : 'false';
+	$label = $ops['label'] !== null ? $ops['label'] : '';
+	$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+	$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+	$fillcolor = $ops['fillcolor'] !== null ? $ops['fillcolor'] : null;
+	$fillopacity = $ops['fillopacity'] !== null ? $ops['fillopacity'] : 0.3;
+	$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+
+	if (count($param) == 3 && is_jsxpoint($param[0]) && is_jsxpoint($param[1]) && is_jsxpoint($param[2])) {
+		// Circle through three points
+		$out .= "board_{$boardID}.create('circle', [";
+		$out .= jsx_pointToJS($param[0]).", ";
+		$out .= jsx_pointToJS($param[1]).", ";
+		$out .= jsx_pointToJS($param[2])."], ";
+		
+	} else if (count($param) == 2 && is_jsxpoint($param[0]) && is_jsxpoint($param[1])) {
+		
+		// Circle with center and point
+		$out .= "board_{$boardID}.create('circle', [";
+		$out .= jsx_pointToJS($param[0]).", ".jsx_pointToJS($param[1])."], ";
+
+	} else if (count($param) == 2 && is_jsxpoint($param[0]) && is_jsxvalue($param[1])) {
+		// Circle with center and radius
+		$out .= "board_{$boardID}.create('circle', [";
+		$out .= jsx_pointToJS($param[0]).", ".jsx_valueToJS($param[1])."], ";
+		
+	} else {
+		echo "Invalid parameters for circle, use: [[x, y], r], [[x1, y1], [x2, y2]], or give three points";
+		$is_error = true;
+	}
+	
+	if ($is_error == false) {
+		// Set attributes and close up shop.
+		$out .= "{
+			highlight: {$highlight},
+            fixed: {$fixed},
+            strokeColor: '{$color}',
+            dash: {$dash},
+            strokeWidth: {$width},
+			visible: {$visible},
+			withLabel: {$haslabel},
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+		";
+		if ($fillcolor != null) {
+			$out .= ",fillColor: '{$fillcolor}', fillOpacity: {$fillopacity} })";
+        } else {
+			$out .= '})';
+		}
+		if ($ops['attributes'] !== null) {
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);
+		
+	}
+	
+	$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+	return $id;
+
+}
+
+###########################################################################
+##
+## Adds a polygon on the jsx board
+##
+###########################################################################
+
+function jsxPolygon (&$board, $param, $ops=array()) {
+
+	$id = "polygon_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$out = "";	
+	$inputerror = false;
+
+	// Validate input values
+
+	if (!is_array($param) || count($param) < 3) {
+		$inputerror = true;
+	} else {
+		foreach($param as $item) {
+			if (!is_jsxpoint($item)) {
+				$inputerror = true;
+			}
+		}
+	}
+
+	if (!$inputerror) {
+
+		// Set default values
+		
+		$highlight = $ops['highlight'] !== null ? jsx_getbool($ops['highlight']) : 'false';
+		$fixed = $ops['fixed'] !== null ? jsx_getbool($ops['fixed']) : 'true';
+		$color = $ops['color'] !== null ? $ops['color'] : 'blue';
+		$fillcolor = $ops['fillcolor'] !== null ? $ops['fillcolor'] : 'blue';
+		$fillopacity = $ops['fillopacity'] !== null ? $ops['fillopacity'] : 0.4;
+		$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+
+		$dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+		$width = $ops['width'] !== null ? $ops['width'] : 2;
+
+		// Begin object creation
+
+		$out .= "var {$id} = board_{$boardID}.create('polygon', [";
+		
+		$count = 1;
+		$total = count($param);
+		
+		foreach($param as $point) {
+			$out .= jsx_pointToJS($point);
+			$count < $total ? $out .= ", " : $out .= "], ";
+			$count += 1;
+		}
+
+		// Set attributes 
+		
+		$out .= "{
+			highlight: {$highlight},
+			fixed: {$fixed},
+			fillColor: '{$fillcolor}',
+			fillOpacity: {$fillopacity},
+			visible: {$visible},
+			vertices: {
+				showInfobox: false,
+				fixed: true,
+				highlight: false,
+				visible: false
+			},
+			borders: {
+				fixed: {$fixed},
+				highlight: {$highlight},
+				showInfobox: false,
+				strokeColor: '{$color}',
+				strokeWidth: {$width},
+				dash: {$dash}
+			},
+			withLabel: {$haslabel},
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+		})";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! Invalid parameters for polygon object, an array of at least three points expected.";
+	}
+}
+
+###########################################################################
+##
+## Function to draw a line on a JSX board
+##
+###########################################################################
+
+function jsxLine (&$board, $param, $ops=array()) {
+
+	$id = "line_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+
+	if (!is_array($param) || count($param) != 2) {
+		$inputerror = true;
+	} else {
+		foreach($param as $item) {
+			if (!is_jsxpoint($item)) {
+				$inputerror = true;
+			}
+		}
+	}
+
+	if (!$inputerror) {
+
+		// Set default values
+		$highlight = $ops['highlight'] !== null ? jsx_getbool($ops['highlight']) : 'false';
+		$fixed = $ops['fixed'] !== null ? jsx_getbool($ops['fixed']) : 'true';
+		$color = $ops['color'] !== null ? $ops['color'] : 'black';
+		$dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+		$width = $ops['width'] !== null ? $ops['width'] : 2;
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+		$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+
+		// Begin object creation
+
+		$out = "var {$id} = board_{$boardID}.create('line', [";
+		$out .= jsx_pointToJS($param[0]).", ";
+		$out .= jsx_pointToJS($param[1])."],";
+
+		// Set attributes 
+		
+		$out .= "{
+            highlight: {$highlight},
+            fixed: {$fixed},
+            strokeColor: '{$color}',
+            dash: {$dash},
+            strokeWidth: {$width},
+			withLabel: {$haslabel},
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false },
+			visible: {$visible}
+		})";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+
+		$out .= jsx_setlabel($id, $label);	
+
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! Invalid parameters for JSX Line. Start point and end point expected.";
+	}
+}  
+
+###########################################################################
+##
+## Function to draw a segment on a JSX board
+##
+###########################################################################
+
+function jsxSegment (&$board, $param, $ops=array()) {
+
+	$id = "segment_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+	if (!is_array($param) || count($param) != 2) {
+		$inputerror = true;
+	} else {
+		foreach($param as $item) {
+			if (!is_jsxpoint($item)) {
+				$inputerror = true;
+			}
+		}
+	}
+
+	if (!$inputerror) {
+
+		// Set default values
+		$highlight = $ops['highlight'] !== null ? jsx_getbool($ops['highlight']) : 'false';
+		$fixed = $ops['fixed'] !== null ? jsx_getbool($ops['fixed']) : 'true';
+		$color = $ops['color'] !== null ? $ops['color'] : 'black';
+		$dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+		$width = $ops['width'] !== null ? $ops['width'] : 2;
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+		$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+
+		// Begin object creation
+
+		$out = "var {$id} = board_{$boardID}.create('segment', [";
+		$out .= jsx_pointToJS($param[0]).", ";
+		$out .= jsx_pointToJS($param[1])."],";
+
+		//	name: '" .$label. "',
+
+		// Set attributes 
+		$out .= "{
+            highlight: {$highlight},
+            fixed: {$fixed},
+            strokeColor: '{$color}',
+            dash: {$dash},
+            strokeWidth: {$width},
+			visible: {$visible},
+			withLabel: {$haslabel},
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+        })";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+				
+		$out .= jsx_setlabel($id, $label);
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! Invalid parameters for JSX segment. Start point and end point expected.";
+	}
+}
+
+###########################################################################
+##
+## Draws a ray extending from point $param[0] through point $param[1]
+##
+###########################################################################
+
+function jsxRay (&$board, $param, $ops=array()) {
+
+	$id = "ray_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+	if (!is_array($param) || count($param) != 2) {
+		$inputerror = true;
+	} else {
+		foreach($param as $item) {
+			if (!is_jsxpoint($item)) {
+				$inputerror = true;
+			}
+		}
+	}
+
+	if (!$inputerror) {
+
+		// Set default values
+		$highlight = $ops['highlight'] !== null ? jsx_getbool($ops['highlight']) : 'false';
+		$fixed = $ops['fixed'] !== null ? jsx_getbool($ops['fixed']) : 'true';
+		$color = $ops['color'] !== null ? $ops['color'] : 'black';
+		$dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+		$width = $ops['width'] !== null ? $ops['width'] : 2;
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+		$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+
+		// Begin object creation
+
+		$out = "var {$id} = board_{$boardID}.create('line', [";
+		$out .= jsx_pointToJS($param[0]).", ";
+		$out .= jsx_pointToJS($param[1])."],";
+
+		// Set attributes 
+		
+		$out .= "{
+			highlight: {$highlight},
+            fixed: {$fixed},
+            strokeColor: '{$color}',
+            dash: {$dash},
+            strokeWidth: {$width},
+			visible: {$visible},
+			withLabel: {$haslabel},
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false },
+            lastArrow: true,
+            straightFirst: false
+        })";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);	
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! Invalid parameters for JSX ray. Two points expected.";
+	}
+}  
+
+
+// Draws a 2D vector, represented as an arrow starting at point $param[0]
+//   and terminates at point $param[1], or as a magnitude and direction
+//   given in radians. In the second form, the vector will be in standard
+//   position.
+
+function jsxVector (&$board, $param, $ops=array()) {
+
+	$id = "vector_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+	if (is_jsxpoint($param[0]) && is_jsxpoint($param[1])) {
+		$point0 = $param[0];
+		$point1 = $param[1];
+	} else if (is_jsxvalue($param[0]) && is_jsxvalue($param[1])) {
+		$r = $param[0];
+		$t = $param[1];
+		$offset = $ops['offset'] !== null ? $ops['offset'] : 'false';
+		if ($offset !== 'false') {
+			$point0 = ["$offset[0]", "$offset[1]"]; 
+			$point1 = ["$offset[0] + $r * Math.cos($t)", "$offset[1] + $r * Math.sin($t)"];
+		} else {
+			$point0 = [0, 0]; 
+			$point1 = ["$r * Math.cos($t)", "$r * Math.sin($t)"];
+		}
+	} else {
+		$inputerror = true;
+	}
+
+	if (!$inputerror) {
+
+		// Set default values
+		$highlight = $ops['highlight'] !== null ? jsx_getbool($ops['highlight']) : 'false';
+		$fixed = $ops['fixed'] !== null ? jsx_getbool($ops['fixed']) : 'true';
+		$color = $ops['color'] !== null ? $ops['color'] : 'black';
+		$dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+		$width = $ops['width'] !== null ? $ops['width'] : 2;
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+
+		// Begin object creation
+		$out = "var {$id} = board_{$boardID}.create('arrow', [";
+		$out .= jsx_pointToJS($point0).", ";
+		$out .= jsx_pointToJS($point1)."],";	
+
+		// Set attributes 
+		$out .= "{
+            highlight: {$highlight},
+            fixed: {$fixed},
+            strokeColor: '{$color}',
+            strokeWidth: {$width},
+            dash: {$dash},
+			withLabel: {$haslabel},
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+        })";		
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);	
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! Invalid parameters for JSX vector. Initial and terminal points expected.";
+	}
+}  
+
+// Draws a tangent line to a curve at a glider point.
+// Param:
+//    - reference to glider that is already attached to a curve
+// Ops:
+//    - color, dash, width, visible, label
+
+function jsxTangent(&$board, $param, $ops=array()) {
+
+	$id = "tangent_".uniqid();
+	$boardID = jsx_getboardname($board);
+	
+	// Validate input values
+	if (strpos($param, "glider_") !== false) { 
+
+		// Set default values
+		$color = $ops['color'] !== null ? $ops['color'] : 'black';
+		$dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+		$width = $ops['width'] !== null ? $ops['width'] : 2;
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label']!==null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+		$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+		
+		// Begin object creation
+		$out = "var {$id} = board_{$boardID}.create('tangent', [ {$param} ], { ";
+
+		// Set Attributes
+		$out .= "
+			strokeColor: '{$color}',
+			dash: {$dash},
+			strokeWidth: {$width},
+			visible: {$visible},
+			withLabel: {$haslabel},
+			fixed: false,
+			highlight: false,
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+		})";
+		
+		if ($ops['attributes'] !== null) {
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+
+		$out .= jsx_setlabel($id, $label);
+
+		// Append new output string to the board string{
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! You must provide the name of a glider to attach the tangent line to.";
+	}
+
+}
+
+// Creates an integral object, which allows to shade the area trapped between 
+// a curve and the x-axis. $param[0] is an array of a starting x-value and 
+// ending x-value for the integral, these can be float values or references
+// to other jsx objects. If float values are provided, then a static integral
+// will be created, if jsx objects are provided, then the integral will be
+// interactable. $param[1] is a function created by jsx to find the area
+// under. 
+
+function jsxIntegral (&$board, $param, $ops=array()) {
+
+	$id = "integral_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+	if(!is_jsxpoint($param[0]) || !is_jsxobjectref($param[1])) {
+		$inputerror = true;
+	}
+
+	if (!$inputerror) {
+
+		// Set default values
+		$color = $ops['color'] !== null ? $ops['color'] : 'blue';
+		$fillopacity = $ops['fillopacity'] !== null ? $ops['fillopacity'] : 0.4;
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label']!==null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+
+		// Begin object creation
+		$out = "var {$id} = board_{$boardID}.create('integral', [";
+		$out .= jsx_pointToJS($param[0]).", ";
+		$out .= $param[1]."],";
+
+		// Set attributes 
+		$out .= "{
+			color: '{$color}',
+			fillOpacity: {$fillopacity},
+			withLabel: {$haslabel},
+			fixed: true,
+			highlight: false,
+			curveLeft: { visible: false },
+			curveRight: { visible: false },
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+		})";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! jsxIntegral expects two inputs: the range for the integral [a, b] and a funtion f.";
+	}
+}
+
+// Creates a Riemann sum trapped between a function and the x-axis, or between two
+// different functions. The parameters expected are passed in an array and are: 
+// an array containing the lower endpoint and upper endpoint of the interval and
+// the number of rectangles to use. Each of these items can be numeric that will
+// make them static. You can also use references to other jsx objects in order to
+// make them dynamic. The second parameter can be a single function in order to
+// create rectangles between the x-axis and the function, or an array of functions
+// which will draw the rectanges between the functions. The return is an object 
+// reference that can be used in the creation of other jsx objects.
+
+function jsxRiemannSum (&$board, $param, $ops=array()) {
+
+	$id = "riemannsum_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+	if(!is_array($param[0]) || count($param[0]) != 3) {
+		$inputerror = true;
+	} 
+	if(!is_jsxvalue($param[1])) {
+		if(!is_jsxpoint($param[1])) {
+			$inputerror = true;
+		}
+	}
+
+	if (!$inputerror) {
+
+		// Set default values
+		$type = $ops['type'] !== null ? $ops['type'] : 'left';
+		$inputvariable = $ops['inputvariable'] !== null ? $ops['inputvariable'] : 'x';
+		$color = $ops['color'] !== null ? $ops['color'] : 'blue';
+		$fillcolor = $ops['fillcolor'] !== null ? $ops['fillcolor'] : $color;
+		$fillopacity = $ops['fillopacity'] !== null ? $ops['fillopacity'] : 0.4;
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label']!==null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+
+		// Begin object creation
+
+		$out = "var {$id} = board_{$boardID}.create('riemannsum', [";
+		
+		if(is_array($param[1])) {
+			if(strpos($param[1][0],"_") != false) {
+				$out .= "[{$param[1][0]}_text,";
+			} else {
+				$out .= "[".jsx_functionToJS($param[1][0], $inputvariable).",";
+			}
+			if(strpos($param[1][1],"_") != false) {
+				$out .= "{$param[1][1]}_text],";
+			} else {
+				$out .= jsx_functionToJS($param[1][1], $inputvariable)."],";
+			}
+		} else {
+			// Check to see if the function is a reference to a jsxFunction
+			if(strpos($param[1],"_") != false) {
+				$out .= "{$param[1]}_text,";
+			} else {
+				$out .= jsx_functionToJS($param[1], $inputvariable).",";
+			}
+		}
+		
+		$out .= jsx_valueToJS($param[0][2]).", ";
+		$out .= "'{$type}', ";
+		$out .= jsx_valueToJS($param[0][0]).", ";
+		$out .= jsx_valueToJS($param[0][1])."],";
+
+
+		// Set attributes 
+		
+		$out .= "{
+			strokeColor: '{$color}',
+			fillColor: '{$fillcolor}',
+			fillOpacity: {$fillopacity},
+			withLabel: {$haslabel},
+			fixed: true,
+			highlight: false,
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+		})";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! jsxReimannSum expects an array like [a, b, n] for the first input, and either a
+			function or an array of two functions for the second.";
+	}
+}
+
+
+###########################################################################
+##
+## Creates a text object to place on a JSX board
+##
+###########################################################################
+
+function jsxText (&$board, $param, $ops=array()) {
+
+	$id = "text_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+	if (is_jsxpoint($param[0]) && is_jsxvalue($param[1])) {
+			
+		// Set default values
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$highlight = $ops['highlight'] !== null ? jsx_getbool($ops['highlight']) : 'false';
+		$fixed = $ops['fixed'] !== null ? jsx_getbool($ops['fixed']) : 'true';
+		$color = $ops['color'] !== null ? $ops['color'] : 'black';
+		$anchor = $ops['anchor'] !== null ? $ops['anchor'] : false;
+		$anchorX = $ops['anchorX'] !== null ? $ops['anchorX'] : false;
+		$anchorY = $ops['anchorY'] !== null ? $ops['anchorY'] : false;
+		
+		$useMathJax = strpos($param[1], "`") > -1 ? 'true' : 'false';
+		
+		// Begin object creation
+
+		$out = "var {$id} = board_{$boardID}.create('text', [";
+		
+		if (is_array($param[0])) {
+			$out .= jsx_valueToJS($param[0][0]).", ".jsx_valueToJS($param[0][1]).", ";
+		} else if(is_jsxpointtref($param[0])) {
+			$out .= jsx_valueToJS("$param[0].X()").", ".jsx_valueToJS("$param[0].Y()").", ";
+		}
+		
+		if (count(jsx_getobjectreferences($param[1])) > 0) {
+			$out .= "function() { return {$param[1]}; }],";
+		} else {
+			$out .= "'{$param[1]}'],";
+		}
+
+		// Set attributes 
+		
+		$out .= "{";
+		$out .= "useMathJax: {$useMathJax},";
+		$out .= "fontSize: {$fontsize},";
+		$out .= "highlight: {$highlight},";
+		$out .= "fixed: {$fixed},";
+		$out .= "color: '{$color}',";
+		if($anchor !== false) {
+			$out .= "anchor: {$anchor},"; 
+		}
+		if($anchorX !== false) {
+			$out .= "anchorX: {$anchorX},"; 
+		}
+		if($anchorY !== false) {
+			$out .= "anchorY: {$anchorY},"; 
+		}
+        $out .= "})";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! Invalid parameters given to JSX text object. Expected: location and string.";
+	}
+}  
+ 
+ 
+###########################################################################
+##
+## Creates an angle with three points, $param[1] is the center point.
+##
+###########################################################################
+
+function jsxAngle (&$board, $param, $ops=array()) {
+
+	$id = "angle_".uniqid();
+	$boardID = jsx_getboardname($board);
+	$inputerror = false;
+
+	// Validate input values
+	if (!is_array($param) || count($param) != 3) {
+		$inputerror = true;
+	} else {
+		foreach($param as $item) {
+			if (!is_jsxpoint($item)) {
+				$inputerror = true;
+			}
+		}
+	}
+
+	if (!$inputerror) {
+
+		// Set default values
+		$highlight = $ops['highlight'] !== null ? jsx_getbool($ops['highlight']) : 'false';
+		$fixed = $ops['fixed'] !== null ? jsx_getbool($ops['fixed']) : 'true';
+		$color = $ops['color'] !== null ? $ops['color'] : 'orange';
+		$fillcolor = $ops['fillcolor'] !== null ? $ops['fillcolor'] : 'orange';
+		$fillopacity = $ops['fillopacity'] !== null ? $ops['fillopacity'] : 0.5;
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+
+		// Begin object creation
+		$out = "var {$id} = board_{$boardID}.create('angle', [";
+		$out .= jsx_pointToJS($param[0]).", ";
+		$out .= jsx_pointToJS($param[1]).", ";
+		$out .= jsx_pointToJS($param[2])."],";	
+
+		// Set attributes 
+		$out .= "{
+            highlight: {$highlight},
+            fixed: {$fixed},
+            strokeColor: '{$color}',
+			withLabel: {$haslabel},
+			fillColor: '{$fillcolor}',
+			fillOpacity: {$fillopacity},
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+        })";
+		
+		if ($ops['attributes'] !== null) { 
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+
+		$out .= jsx_setlabel($id, $label);
+
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+		
+	} else {
+		echo "Eek! Error in the parameters to JSX angle. Three points expected.";
+	}
+}  
+ 
+###############################################################################
+##
+##  Adds a function to bhe board
+##
+###############################################################################
+
+function jsxFunction(&$board, $f, $ops=array()) { 
+  
+	$id = "function_".uniqid();
+	$boardID = jsx_getboardname($board);
+
+	// Parameters:
+	//  inputvariable, color, width, dash, domain, label
+	
+	// Make some default values
+	$inpVar = $ops['inputvariable'] !== null ? $ops['inputvariable'] : 'x'; 
+	$color = $ops['color'] !== null ? $ops['color'] : 'blue';
+	$width = $ops['width'] !== null ? $ops['width'] : 2;
+	$dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+	$haslabel = $ops['label'] !== null ? 'true' : 'false';
+	$label = $ops['label'] !== null ? $ops['label'] : '';
+	$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+	$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : '16';
+	$isBounds = ($ops['domain'] !== null && count($ops['domain']) == 2) ? true : false;
+	$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+  
+	$objects = jsx_getobjectreferences($f);
+  
+	// Here we preserve the text of the function in case it is needed elswhere
+	$out = "var {$id}_text = ".jsx_functionToJS($f, $inpVar).";";
+  
+	// Start the output string
+	$out .= "var {$id} = board_{$boardID}.create('functiongraph', [";
+	$out .= jsx_functionToJS($f, $inpVar); 
+  
+	// Handle domain restriction, if provided
+	if ($isBounds) { 
+		$out .= ','.jsx_valueToJS($ops['domain'][0]);
+		$out .= ','.jsx_valueToJS($ops['domain'][1]);
+	}
+	
+	$out .= "]";
+  
+	// Handle attributes, then close up shop.
+	$out .= ", {
+		strokeColor: '{$color}',
+		strokeWidth: {$width},
+		dash: {$dash},
+		fixed: true,
+		highlight: false,
+		visible: {$visible},
+		label: { color: '{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false },
+		withLabel: {$haslabel}
+	})";
+  
+	if ($ops['attributes'] !== null) {
+		$out .= ".setAttribute({$ops['attributes']});";
+	} else {
+		$out .= ";";
+	}
+
+	$out .= jsx_setlabel($id, $label);
+
+	// Append new output string to the board string
+	$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"),0);
+	return $id;
+}
+
+// Adds a parametric graph to a jsx board.
+// Parameters:
+//   - A set of functions defining x & y coordinate pairs
+// Options:
+//   - $tStart and $tEnd: begin and end values for the domain of t
+//   - inputvariable: the variable used in the parametric functions
+//   - color, width
+
+function jsxParametric (&$board, $param, $ops=array()) {
+
+	$id = "parametric_".uniqid();
+	$boardID = jsx_getboardname($board);
+	
+	// Validate input values
+	if (is_jsxpoint($param)) {
+
+		// Set default values
+		$inpVar = $ops['inputvariable'] !== null ? $ops['inputvariable'] : 't'; // input variable
+		$tStart = $ops['domain'][0] !== null ? $ops['domain'][0] :-10; // start value of t
+		$tEnd = $ops['domain'][1] !== null ? $ops['domain'][1] : 10; // end value of t
+		$color = $ops['color'] !== null ? $ops['color'] : 'blue'; // color of graph
+		$width = $ops['width'] !== null ? $ops['width'] : 2; // width of graph
+		$dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : $color;
+		$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+		
+		// Begin object creation
+		$out = "var {$id} = board_{$boardID}.create('curve', [";
+		$out .= jsx_functionToJS($param[0], $inpVar).", "; 
+		$out .= jsx_functionToJS($param[1], $inpVar).", ";
+		$out .= jsx_valueToJS($tStart).", ";
+		$out .= jsx_valueToJS($tEnd)."], ";
+
+		// Set up attributes
+		$out .= "{
+			strokeColor: '{$color}',
+            strokeWidth: {$width},
+            highlight:	false,
+			dash: {$dash},
+			withLabel: {$haslabel},
+			visible: {$visible},
+            name: '{$label}',
+			label: { color: '{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+        })";
+		
+		if ($ops['attributes'] !== null) {
+			$out .= ".setAttribute({$ops['attributes']})";
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);		
+		
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"),0);
+		return $id;
+		
+	} else {
+		echo "Eek! Invalid parameters for paramtric function. Expecting an array with functions for x and y.";
+	}	
+}
+
+// Draws the graph of a Polar function on a jsx board
+//   this is expected in the form of r = f(t)
+//
+// Parameters:
+//   - $inputvariable: allows user to control the name of the variable used
+//   - $rule: the function rule
+//   - $tStart, $tEnd: the lower and upper bounds for theta
+//   - $color, $width
+
+function jsxPolar (&$board, $rule, $ops = array()) {
+	
+	$id = "polar_".uniqid();
+	$boardID = jsx_getboardname($board);
+	
+	// Validate input values
+	if (is_string($rule)) {
+
+		// Set default values
+		$var = $ops['inputvariable'] !== null ? $ops['inputvariable'] : 't'; // input variable
+		$color = $ops['color'] !== null ? $ops['color'] : 'blue'; // color of graph
+		$width = $ops['width'] !== null ? $ops['width'] : 2; // width of graph
+		$dash = $ops['dash'] !== null ? $ops['dash'] : 0;
+		$tStart = $ops['domain'][0] !== null ? $ops['domain'][0] : 0; // start value of t
+		$tEnd = $ops['domain'][1] !== null ? $ops['domain'][1] : 6.283185307; // end value of t
+		$haslabel = $ops['label'] !== null ? 'true' : 'false';
+		$label = $ops['label'] !== null ? $ops['label'] : '';
+		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
+		$fontcolor = $ops['fontcolor'] !== null ? $ops['fontcolor'] : 'black';
+		$visible = $ops['visible'] !== null ? jsx_getbool($ops['visible']) : 'true';
+
+		// Begin object creation
+		$out = "var {$id} = board_{$boardID}.create('curve', [";
+		$out .= jsx_functionToJS($rule, $var).", [0, 0], ";
+  
+		$out .= jsx_valueToJS($tStart).", ";
+		$out .= jsx_valueToJs($tEnd)."], ";
+		
+		// Set attributes
+		$out .= "{
+			curveType: 'polar',
+			highlight: false,
+			fixed: true,
+			dash: {$dash},
+			strokeColor: '{$color}',
+			strokeWidth: {$width},
+			visible: {$visible},
+			name: '{$label}',
+			withLabel: {$haslabel},
+			label: { color:'{$fontcolor}', fontSize: {$fontsize}, useMathJax: true, highlight: false }
+		})";
+		
+		if ($ops['attributes'] !== null) {
+			$out .= ".setAttribute({$ops['attributes']});";
+		} else {
+			$out .= ";";
+		}
+		
+		$out .= jsx_setlabel($id, $label);		
+
+		// Append new output string to the board string
+		$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+		return $id;
+
+	} else {
+		echo "Eek! Polar graph expects at least one input for the function rule.";
+	}
+}
+
+###############################################################################
+##
+##  The remaining functions are dedicated to creating jsx boards that objects
+##    can be placed onto. The only function called by the user is: 
+##    jsxBoard() with an input indicating if a geometric, rectangular,
+##    or polar board should be created for use.
+##
+###############################################################################
+
+function jsxBoard($type, $ops=array()) {
+	//jsx_getscript();
+	
+	$id = uniqid();
+	
+	if($type == 'rectangular') {
+		$board = jsx_createrectangularboard($id, $ops);
+	} elseif ($type == 'polar') {
+		$board = jsx_createpolarboard($id, $ops);
+	} elseif ($type == 'geometry') {
+		$board = jsx_creategeometryboard($id, $ops);
+	}
+
+	return $board;
+	
+}
+
+// Creates a link to the jsx include file
+function jsx_getscript () {
+	
+	if (isset($GLOBALS['assessUIver']) && $GLOBALS['assessUIver'] > 1) {
+		return '<script type="text/javascript" src="https:'.jsx_getlibrarylink().'"></script>';	
+	} else {
+		return 
+			'<script type="text/javascript">if (typeof JXG === "undefined" && typeof JXGscriptloaded === "undefined") {
+			var jsxgloadscript = document.createElement("script");
+			jsxgloadscript.src = "'.jsx_getlibrarylink().'";
+			document.getElementsByTagName("head")[0].appendChild(jsxgloadscript);
+			JXGscriptloaded = true;
+			} </script>';
+	}
+}
+
+// Set up a board. Auxillary functions
+function jsx_setupboard ($label, $width, $height, $centered) {
+	
+	$cntrd = $centered === 'true' ? "margin:auto;" : "";
+	$ratio = 100 * ($height / $width);
+  
+	// Start output string by getting script
+	$out = jsx_getscript();
+  
+	// make board
+	$out .= "<div class='jxgboardwrapper' style='max-width:{$width}px; max-height:{$height}px; {$cntrd}'>";
+	$out .= "<div id='jxgboard_{$label}' style='background-color:#FFF; width:100%; height:0px; padding-bottom:{$ratio}%;'></div>";
+	$out .= "</div>";
+  
+	// Start script
+	$out .= "<script type='text/javascript'>";
+  
+	// We build construction function inline, push function to initstack to load async
+	$out .= "function makeBoard{$label}() {";
+    $out .= "try {";
+	$out .= "JXG.Options.text.fontSize = 16;";
+	$out .= 'JXG.Options.text.cssDefaultStyle = "font-family:Serif;";';
+	$out .= 'JXG.Options.axis.lastArrow.size = 5;';
+	
+	// This is where new content gets inserted
+	$out .= "/*INSERTHERE*/";
+	
+	// End of construction function. Push it to initstack
+	$out .= "} catch(err){console.log(err);}";
+    $out .= "}";
+	$out .= "initstack.push(makeBoard{$label});";
+    $out .= "</script>"; // End of script
+
+	return $out;
+
+}
+
+// creates a board with no axes
+function jsx_creategeometryboard($label, $ops) {
+  
+	// Set default values
+	$width = $ops['size'][0] !== null ? $ops['size'][0] : 350; // board width
+	$height = $ops['size'][1] !== null ? $ops['size'][1] : 350; // board height
+	$navBar = $ops['navbar'] !== null ? jsx_getbool($ops['navbar']) : 'true';
+	$zoom = $ops['zoom'] !== null ? jsx_getbool($ops['zoom']) : 'true';
+	$pan = $ops['pan'] !== null ? jsx_getbool($ops['pan']) : 'true';
+	$centered = $ops['centered'] !== null ? jsx_getbool($ops['centered']) : 'false';
+  
+	//set the min and max x-values if provided, else default to [-5, 5]
+	$xmin = $ops['bounds'][0] !== null ? $ops['bounds'][0] : -5;
+	$xmax = $ops['bounds'][1] !== null ? $ops['bounds'][1] : 5;
+	$ymin = $ops['bounds'][2] !== null ? $ops['bounds'][2] : -5;
+	$ymax = $ops['bounds'][3] !== null ? $ops['bounds'][3] : 5;
+
+	// Create the board
+	$out = "window.board_{$label} = JXG.JSXGraph.initBoard('jxgboard_{$label}', {
+        boundingbox: [{$xmin}, {$ymax}, {$xmax}, {$ymin}],
+        axis: false,
+        showCopyright: false,
+        showNavigation: {$navBar},
+        zoom: {
+			enabled: {$zoom},
+            factorX: 1.25,
+            factorY: 1.25,
+            wheel: {$zoom},
+            needshift: false,
+            eps: 0.1
+        },
+        pan: {
+            enabled: {$pan},
+            needshift: false
+        }
+    });";
+
+	$boardinit = jsx_setupboard($label, $width, $height, $centered);
+	return substr_replace($boardinit, $out, strpos($boardinit, "/*INSERTHERE*/"), 0);
+}
+
+
+// creates a board with a rectangular set of axes on it
+function jsx_createrectangularboard ($label, $ops = array()) {
+	
+	// Set default values
+	$width = $ops['size'][0] !== null ? $ops['size'][0] : 350; // board width
+	$height = $ops['size'][1] !== null ? $ops['size'][1] : 350; // board height
+	$navBar = $ops['navbar'] !== null ? jsx_getbool($ops['navbar']) : 'true';
+	$zoom = $ops['zoom'] !== null ? jsx_getbool($ops['zoom']) : 'true';
+	$pan = $ops['pan'] !== null ? jsx_getbool($ops['pan']) : 'true';
+	$centered = $ops['centered'] !== null ? jsx_getbool($ops['centered']) : 'false';
+   
+	//set the min and max x-values if provided, else default to [-5, 5]
+	$xmin = $ops['bounds'][0] !== null ? $ops['bounds'][0] : -5;
+	$xmax = $ops['bounds'][1] !== null ? $ops['bounds'][1] : 5;
+	$ymin = $ops['bounds'][2] !== null ? $ops['bounds'][2] : -5;
+	$ymax = $ops['bounds'][3] !== null ? $ops['bounds'][3] : 5;
+
+	$minorTicksX = $ops['minorticks'][0] !== null ? $ops['minorticks'][0] : 1;
+	$minorTicksY = $ops['minorticks'][1] !== null ? $ops['minorticks'][1] : 1;
+	$ticksDistanceX = $ops['ticksdistance'][0] !== null ? $ops['ticksdistance'][0] : floor((($xmax)-($xmin))/8);
+	$ticksDistanceY = $ops['ticksdistance'][1] !== null ? $ops['ticksdistance'][1] : floor((($ymax)-($ymin))/8);
+
+	$useMathJax = ($ops['axislabel'] !== null && (strpos($ops['axislabel'][0], "`") > -1 || strpos($ops['axislabel'][1], "`") > -1)) ? "true" : "false";
+
+	// Start output
+	$out = "JXG.Options.layer = { numlayers: 20, text: 9, point: 9, glider: 9, arc: 8, line: 7, circle: 6,
+            curve: 5, turtle: 5, polygon: 3, sector: 3, angle: 3, integral: 3, axis: 3, ticks: 2, grid: 1, image: 0, trace: 0};";
+   
+	// Create the board
+	$defaultAxis = $ops['ticksdistance'] ? "false" : "true";
+	$out .= "window.board_{$label} = JXG.JSXGraph.initBoard('jxgboard_{$label}', {
+             boundingbox: [{$xmin}, {$ymax}, {$xmax}, {$ymin}],
+             axis: false,
+             showCopyright: false,
+             showNavigation: {$navBar},
+             zoom: {
+				enabled: {$zoom},
+				factorX: 1.25,
+				factorY: 1.25,
+				wheel: {$zoom},
+				needshift: false,
+				eps: 0.1
+             },
+             pan: {
+				enabled: {$pan},
+				needshift: false
+			 }
+           });";
+
+	$out .= "var xTicks{$label}, yTicks{$label}, bb{$label};";
+   
+	// x-axis
+	$out .= "var xaxis{$label} = board_{$label}.create('axis', [[0,0], [1,0]], {
+               strokeColor:'black',
+               strokeWidth: 2,
+               highlight:false,
+               name:'" . ($ops['axislabel'][0] != null ? $ops['axislabel'][0] : "") . "',
+               withLabel:true,
+               label: {position:'rt', offset:[-15,15], highlight:false, useMathJax:{$useMathJax}}
+             });";
+	// Remove standard ticks and create new ones based off of tickDistance
+	$out .= "xaxis{$label}.removeAllTicks();";
+	$out .= "var xticks{$label} = board_{$label}.create('ticks',[xaxis{$label}], {
+             ticksDistance: {$ticksDistanceX},
+             strokeColor: 'rgba(150,150,150,0.85)',
+             majorHeight:-1,
+             minorHeight: -1,
+             highlight:false,
+             drawLabels:true,
+             label:{offset:[0,-5], anchorY:'top', anchorX:'middle', highlight:false},
+             minorTicks: {$minorTicksX}
+           });";
+
+	// y-axis
+	$out .= "var yaxis{$label} = board_{$label}.create('axis', [[0,0],[0,1]], {
+               strokeColor:'black',
+               strokeWidth: 2,
+               highlight:false,
+               name:'" . ($ops['axislabel'][1] != null ? $ops['axislabel'][1] : "") . "',
+               withLabel:true,
+               label: {position:'rt', offset:[10,-15], highlight:false, useMathJax:{$useMathJax}}
+             });";
+	
+	// Remove standard ticks and create new ones based off of tickDistance
+    $out .= "yaxis{$label}.removeAllTicks();";
+    $out .= "var yticks{$label} = board_{$label}.create('ticks',[yaxis{$label}], {
+              ticksDistance: {$ticksDistanceY},
+              strokeColor: 'rgba(150,150,150,0.85)',
+              majorHeight:-1,
+              minorHeight: -1,
+              highlight:false,
+              drawLabels:true,
+              label:{offset:[-5, 0], anchorY:'middle', anchorX:'right', highlight:false},
+              minorTicks: {$minorTicksY}
+            });";
+
+    // If zoom is allowed, we need to make sure ticks behave nicely
+    if ($zoom == "true") {
+		$out .= "xticks{$label}.ticksFunction = function(){return xTicks{$label};};";
+		$out .= "yticks{$label}.ticksFunction = function(){return yTicks{$label};};";
+      
+		// Tick handling functions
+		$out .= "var setTicks{$label} = function(){
+          bb = board_{$label}.getBoundingBox();
+          xTicksVal = Math.pow(10, Math.floor((Math.log(0.6*(bb[2]-bb[0])))/Math.LN10));
+          if( (bb[2]-bb[0])/xTicksVal > 6) {
+        	  xTicks{$label} = xTicksVal;
+        	} else {
+        	  xTicks{$label} = 0.5* xTicksVal;
+        	}
+        	yTicksVal = Math.pow(10, Math.floor((Math.log(0.6*(bb[1]-bb[3])))/Math.LN10));
+        	if( (bb[1]-bb[3])/yTicksVal > 6) {
+        	  yTicks{$label} = yTicksVal;
+        	} else {
+        	  yTicks{$label} = 0.5* yTicksVal;
+        	}
+        	board_{$label}.fullUpdate(); // full update is required
+        };
+        setTicks{$label}();
+        board_{$label}.on('boundingbox', function(){setTicks{$label}();});
+        board_{$label}.fullUpdate();";
+    }
+    
+	$boardinit = jsx_setupboard($label, $width, $height, $centered);
+    return substr_replace($boardinit, $out, strpos($boardinit, "/*INSERTHERE*/"), 0);
+
+}
+
+// creates a set of axes, and a board to construct on.
+function jsx_createpolarboard ($label, $ops=array()) {
+
+	// Add some default values
+	$size = $ops['size'][0] !== null ? $ops['size'][0] : 350;
+	$navBar = $ops['navbar'] !== null ? jsx_getbool($ops['navbar']) : 'true';
+	$zoom = $ops['zoom'] !== null ? jsx_getbool($ops['zoom']) : 'false';
+	$pan = $ops['pan'] !== null ? jsx_getbool($ops['pan']) : 'false';
+	$centered = $ops['centered'] !== null ? jsx_getbool($ops['centered']) : 'false';
+   
+	//set the min and max x-values if provided, else default to [-5, 5]
+	$rmax = $ops['r'][0] !== null ? (float) $ops['r'][0] : 5;
+	$rInc = $ops['r'][1] !== null ? (float) $ops['r'][1] : 1;
+	$thetaType = $ops['theta'][0] !== null ? $ops['theta'][0] : 'radian';
+	$thetaInc = $ops['theta'][1] !== null ? (float) $ops['theta'][1] : 1;
+
+	$rMaxBoard = 1.2 * $rmax;
+	$rMaxLabel = 1.1 * $rmax;
+
+	$boardYScale = $ops['padtop'] !== null ? 1.1 : 1;
+	$boardHeight = $boardYScale * $size;
+	$yMax = (1 + 2*($boardYScale - 1)) * $rMaxBoard;
+
+	// Layering options. Push the axis in front of ticks
+	$out = "JXG.Options.layer = { numlayers: 20, text: 9, point: 9, 
+		glider: 9, arc: 8, line: 7, circle: 6, curve: 8, turtle: 5, 
+		polygon: 3, sector: 3, angle: 3, integral: 3, axis: 3, ticks: 2, 
+		grid: 1, image: 0, trace: 0}; ";
+		
+	$out .= "JXG.Options.text.fontSize = 18;";
+	//$out .= "JXG.Options.text.useMathJax = true;";
+   
+	// Create the board
+	$defaultAxis = $ops['ticksdistance'] ? "false" : "true";
+	$out .= "
+		window.board_{$label} = JXG.JSXGraph.initBoard('jxgboard_{$label}', {
+			boundingbox: [-{$rMaxBoard}, {$yMax}, {$rMaxBoard}, -{$rMaxBoard}],
+			axis: false,
+			showCopyright: false,
+			showNavigation: {$navBar},
+			zoom: {
+				enabled: {$zoom},
+				factorX: 1.25,
+				factorY: 1.25,
+				wheel: {$zoom},
+				needshift: false,
+				eps: 0.1
+			},
+			pan: {
+				enabled: {$pan},
+				needshift: false
+			}
+		});
+	";
+
+	// Create radial circles, label them
+    $out .= "
+		var r = {$rInc};
+		while (r <= {$rmax}){
+			board_{$label}.create('circle',[[0,0], r], {
+				highlight: false,
+				fixed:true,
+				strokeColor: '#b6b6b6',
+				strokeWidth: 1
+			});
+			board_{$label}.create('text', [r, 0, r], {
+				highlight:false,
+				fixed:true,
+				anchorX: 'middle',
+				anchorY:'top'
+			});
+			r += {$rInc};
+		}
+    ";
+
+    // Add in the angular lines
+    switch ($thetaType){
+		case "pi":
+			// Start with a gcd function to use in labeling angles
+			$out .= "
+				function gcd(a, b){
+					if (!b){return a;}
+					return gcd(b, a%b);
+				}
+				function formatPiFrac(a, b){
+					var num = Math.round(a/gcd(a, b));
+					var den = Math.round(b/gcd(a,b));
+					if (num==1 && den==1){
+						return '&pi;';
+					} else if (num == 1){
+						return '&pi;/'+den;
+					} else if (den == 1){
+						return num+'&pi;';
+					} else {
+						return num+'&pi;/'+den;
+					}
+				}
+				var inc = {$thetaInc};
+					for (var i=0; i<=2*inc-1; i++){
+						board_{$label}.create('segment', [[0, 0], [{$rmax}*Math.cos(i*Math.PI/inc), {$rmax}*Math.sin(i*Math.PI/inc)]], {
+							straightFirst: false,
+							fixed: true,
+							highlight: false,
+							strokeColor: '#b6b6b6',
+							strokeWidth: (i==0 ? 3 : 1)
+						});
+						if (i!=0){
+							board_{$label}.create('text', [{$rMaxLabel}*Math.cos(i*Math.PI/inc), {$rMaxLabel}*Math.sin(i*Math.PI/inc), formatPiFrac(i,inc)], {
+								fixed: true,
+								highlight: false,
+								anchorX: 'middle',
+								anchorY: 'middle'
+							});
+						}
+					}
+				";
+			break;
+      
+			// Degree case. Nothing special here
+			case "degrees":
+				$out .= "
+					var t = 0;
+					while (Math.abs(t) < 360){
+						board_{$label}.create('segment', [[0, 0], [{$rmax}*Math.cos(t*Math.PI/180), {$rmax}*Math.sin(t*Math.PI/180)]], {
+							straightFirst: false,
+							fixed: true,
+							highlight: false,
+							strokeColor: '#b6b6b6',
+							strokeWidth: (t==0 ? 3 : 1)
+						});
+						if (t!=0){
+							board_{$label}.create('text', [{$rMaxLabel}*Math.cos(t*Math.PI/180), {$rMaxLabel}*Math.sin(t*Math.PI/180), t+'&deg;'], {
+								fixed: true,
+								highlight: false,
+								anchorX: 'middle',
+								anchorY: 'middle',
+								fontSize: 16
+							});
+						}
+						t += {$thetaInc};
+					}
+				";
+			break;
+			
+			// Custom unit of angle measure.
+			// Increment now becomes number of units in one full rotation
+			case "custom":
+				$out .= "
+					var n = {$thetaInc};
+					var sn = Math.floor(n);
+					for (var i=0; i<sn; i++){
+						board_{$label}.create('segment', [[0, 0], [{$rmax}*Math.cos(i*2*Math.PI/n), {$rmax}*Math.sin(i*2*Math.PI/n)]], {
+							straightFirst: false,
+							fixed: true,
+							highlight: false,
+							strokeColor: '#b6b6b6',
+							strokeWidth: (i==0 ? 3 : 1)
+						});
+						if (i!=0){
+							board_{$label}.create('text', [{$rMaxLabel}*Math.cos(i*2*Math.PI/n), {$rMaxLabel}*Math.sin(i*2*Math.PI/n), i], {
+								fixed: true,
+								highlight: false,
+								anchorX: 'middle',
+								anchorY: 'middle'
+							});
+						}
+					}
+				";
+			break;
+      
+			// The "radian" case, and fallback
+			default:
+				$out .= "
+					var t = 0;
+					while (Math.abs(t) < 6.283185307){
+						board_{$label}.create('segment', [[0,0], [{$rmax}*Math.cos(t), {$rmax}*Math.sin(t)]], {
+							straightFirst: false,
+							fixed: true,
+							highlight: false,
+							strokeColor: '#b6b6b6',
+							strokeWidth: (t==0 ? 3 : 1)
+						});
+						if (t!=0){
+							board_{$label}.create('text', [{$rMaxLabel}*Math.cos(t), {$rMaxLabel}*Math.sin(t), t], {
+								fixed: true,
+								highlight: false,
+								anchorX: 'middle',
+								anchorY: 'middle'
+							});
+						}
+						t += {$thetaInc};
+					}
+				";
+	}
+    
+	// Get initial board, add this output string to it.
+    $boardinit = jsx_setupboard($label, $size, $boardHeight, $centered);
+    return substr_replace($boardinit, $out, strpos($boardinit, "/*INSERTHERE*/"), 0);
+}
+
+// Temporarily pauses all updates to a board object so that a lot of objects
+// can be drawn more quickly
+function jsxSuspendUpdate(&$board) {
+	$boardID = jsx_getboardname($board);
+	$out = "board_{$boardID}.suspendUpdate();";
+	$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+}
+
+// Unpauses updates to a board object so that objects will become interactive
+// again
+function jsxUnsuspendUpdate(&$board) {
+	$boardID = jsx_getboardname($board);
+	$out = "board_{$boardID}.unsuspendUpdate();";
+	$board = substr_replace($board, $out, strpos($board, "/*INSERTHERE*/"), 0);
+}
+
+
+##############################################################################
+##
+##  The following functions are used to make grading questions more efficient
+##
+##############################################################################
+
+// Takes a point, denoted as (x,y) in string format as input and returns 
+// the x coordinate of the point
+
+function jsx_getXCoord($point) {
+	// Remove all spaces from the point string
+	$point = str_replace(' ', '', $point);
+	$start = stringpos("(", $point) + 1;
+	$end = stringpos(",", $point);
+	return substr($point, $start, $end - $start);
+}
+
+// Takes a point, denoted as (x,y) in string format as input and returns 
+// the y coordinate of the point
+
+function jsx_getYCoord($point) {
+	// Remove all spaces from the point string
+	$point = str_replace(' ', '', $point); 
+	$start = stringpos(",", $point) + 1;
+	$end = stringpos(")", $point);
+	return substr($point, $start, $end - $start);
+}
+
+// Takes a point, denoted as (x,y) in string format as input and returns 
+// the x and y coordinates of the point as an array
+function jsx_getCoords($point) {
+	return [jsx_getXCoord($point), jsx_getYCoord($point)];
+}
+
+###############################################################################
+##
+##  The following functions are internal helper functions designed to make
+##    coding objects easier and less prone to error.
+##
+###############################################################################
+
+// Returns true if the $item provided is a reference to an object 
+// type found in the objects type list. If $strict is set to true, 
+// then the function returns true if the $items is only and object
+// and has no property function attached. 
+// A proper object reference looks like: point_iH5j2k31aB4jk
+
+function is_jsxobjectref($item, $strict = true) {
+	
+	if ($item !== null && is_string($item)) {
+		if ($strict) {
+			$obj_pattern = "/^\s*(".jsx_validobjectlist("|").")_\w{".jsx_idlen()."}\s*$/i";
+		} else {
+			$obj_pattern = "/^\s*(".jsx_validobjectlist("|").")_\w{".jsx_idlen()."}/i";
+		}
+		return preg_match($obj_pattern, $item);
+	} else {
+		return false;
+	}
+	
+}
+
+// Returns true if the provided object is a point reference of some
+// kind of point in JSX Graph. This can be a point, a glider, a midpoint,
+// the center of a circle, etc. 
+
+function is_jsxpointtref($item) {
+	if ($item !== null && is_string($item)) {
+		$point_pattern = "/^\s*(point|glider)_\w{".jsx_idlen()."}/i";
+		return preg_match($point_pattern, $item);
+	}
+}
+
+// A point will look like an array of two values. You may use numeric entries,
+// php variables, a reference to another jsx point, or one of the coordinates can
+// be the x or y property of another jsx point
+
+function is_jsxpoint($item) {
+	
+	// Make sure we have an array of two objects: the item looks like [x, y]
+	if (is_array($item) && count($item) == 2) {
+
+		// And it has two values x and y
+		if (is_jsxvalue($item[0]) && is_jsxvalue($item[1])) {
+			return true;
+		}
+		
+	}
+	
+	// If $item is a reference to a jsx point, then is is valid too
+	if (is_jsxpointtref($item)) {
+		return true;
+	}
+		
+	// If neither of those cases applies, this is not a point
+	return false;
+	
+}
+
+// A value will either be a numeric constanst or a string that contains a
+// formula to be executed
+
+function is_jsxvalue($item) {
+	if(is_numeric($item) || is_string($item)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+// Returns a list of the different valid object types as a string
+// separated by comma (default) or any other character 
+function jsx_validobjectlist($sep = null) {
+	
+	$separator = is_null($sep) ? "," : $sep;
+	$len = -strlen($separator);
+	$str = "";
+	
+	foreach(jsx_validobjects() as $obj) {
+		$str .= $obj . $separator;
+	}
+	
+	return substr($str, 0, $len);
+}
+
+// Finds all the referneces to jsxobjects within a string
+function jsx_getobjectreferences($str) {
+	
+	$idLen = jsx_idlen();
+	$objs = jsx_validobjectlist("|");
+
+	$property_pattern = "/(?:".$objs.")_\w{".jsx_idlen()."}\.\w*\(\)/i";
+	$object_pattern = "/(?:".$objs.")_\w{".jsx_idlen()."}/i";
+	
+	// First find all the property references, like $p.X()
+	preg_match_all($property_pattern, $str, $properties);
+	
+	// Delete all those references
+	$str = preg_replace($property_pattern, "", $str);
+	
+	// Now look for any remaining object references with no properties
+	preg_match_all($object_pattern, $str, $objects);
+	
+	return array_merge($properties[0], $objects[0]);
+
+}
+
+// Determines the board name in order to be able to create and access objects
+function jsx_getboardname($board) {
+
+	$labStart = strpos($board, "jxgboard_") + 9;
+	$labEnd = strpos($board, "'", $labStart);
+	$label = substr($board, $labStart, $labEnd - $labStart);
+	
+	return $label;
+}
+
+function jsx_getslidercount($board) {
+	$slider_pattern = "/var\s+slider_\w{" . jsx_idlen() . "}/i";
+	return preg_match_all($slider_pattern, $board);
+}
+
+//  Converts a point in the form [x, y], ["$p.Value() + 5", 3], $p,
+//    etc., in to a piece of javascript than can be interprested.
+//    Result is wrapped in [,] to define the point.
+
+function jsx_pointToJS($point) {
+	
+	if (is_array($point)) {
+		$js .= "[".jsx_valueToJS($point[0]).", ".jsx_valueToJS($point[1])."]";
+	} else if(is_jsxpointtref($point)) {
+		$js = $point;
+	}
+	return $js;
+	
+}
+
+
+//  Converts a value encoded into a string into a piece of 
+//    javascript that can be executed. Result is not wrapped
+//    in any additional notation. The extra set of parenthesis 
+//    around the {$obj} replacement value handle issues of two
+//    negative values ocurring in a row.
+
+function jsx_valueToJS($value) {
+	
+	$js = "";
+	if (is_numeric($value)) {
+		$js = "{$value}";
+	} else {
+		$objs = jsx_getobjectreferences($value);
+		$js = "function() {";
+		$js .= "var xs = '{$value}';";
+		foreach($objs as $obj) {
+			// check to see if user just sent the reference to a slider, this
+			// then adds the ".Value()" function on the end for simplier syntax
+			if ((strpos($obj, "slider") !== false) && (strpos($obj, "Value()") === false)) {
+				$js .= "xs = xs.replace('{$obj}', '('+{$obj}.Value()+')' );";
+			} else {
+				$js .= "xs = xs.replace('{$obj}', '('+{$obj}+')' );";
+			}
+		}
+		$js .= "with (Math) var x = eval(mathjs(xs)); return x;";
+		$js .= "}";
+	}	
+	return $js;
+}
+
+//  Converts a text-object encoded into a string into a piece of 
+//    javascript that can be used to display values of objects on
+//    a jsx board. $decimals is used to round values to a given
+//    number of decimal places.
+
+function jsx_textToJS($text, $decimals) {
+	
+	$js = "";
+
+	$objs = jsx_getobjectreferences($text);
+	$js = "function() {";
+	$js .= "var ts = '{$text}';";
+	foreach($objs as $obj) {
+		// check to see if user just sent the reference to a slider, this
+		// then adds the ".Value()" function on the end for simplier syntax
+		if ((strpos($obj, "slider") !== false) && (strpos($obj, "Value()") === false)) {
+			$js .= "ts = ts.replace('{$obj}', Math.round(Math.pow(10, {$decimals}) * {$obj}.Value()) / Math.pow(10, {$decimals}));";
+		} else {
+			$js .= "ts = ts.replace('{$obj}', Math.round(Math.pow(10, {$decimals}) * {$obj}) / Math.pow(10, {$decimals}));";
+		}
+	}
+	$js .= "return ts;";
+	$js .= "}";
+		
+	return $js;
+}
+
+// Converts a function provided as a string to a piece of javascript
+//   code that can be executed. $rule is the function rule, and $var
+//   is the independent variable of the function.
+
+function jsx_functionToJS($rule, $var) {
+	
+	$js = "";
+
+	$objs = jsx_getobjectreferences($rule);
+
+	$js = "function({$var}) {";
+	$js .= "var ts = '{$rule}';";
+	foreach($objs as $obj) {
+		// check to see if user just sent the reference to a slider, this
+		// then adds the ".Value()" function on the end for simplier syntax
+		if ((strpos($obj, "slider") !== false) && (strpos($obj, "Value()") === false)) {
+			$js .= "ts = ts.replace('{$obj}', '('+{$obj}.Value()+')');";
+		} else {
+			$js .= "ts = ts.replace('{$obj}', '('+{$obj}+')');";
+		}
+	}
+	$js .= "with (Math) var result = eval(mathjs(ts, '{$var}'));
+            return result; }";
+		
+	return $js;
+}
+
+// Allows user to input values of boolean or string to represent boolean
+// values from the options input strings
+
+function jsx_getbool($bool) {
+	if ($bool === true || $bool === 'true') { 
+		return 'true';
+	} else {
+		return 'false';
+	}
+}
+
+
+// Affixes a label to a jsx object, sets it up so that it can be dynamic 
+// static
+function jsx_setlabel($id, $label) {
+	
+	if($label !== '') {
+		if(strpos($label, 'this.') !== false) {
+			$label = str_replace('this', $id, $label);
+		}
+
+		if (count(jsx_getobjectreferences($label)) > 0) {
+			$js = "{$id}.label.setText(function() { return {$label}; });";
+		} else {
+			$js = "{$id}.label.setText('{$label}');";
+		}
+		
+		return $js;
+	}
+}
+
+// Creates a colored boarder around the board depending on whether the
+// question was answered correctly or not. This function also replaces
+// the object in the answerbox to its position right before the 'submit'
+// button was pressed by the user.
+
+function jsx_getcolorinterval($boardID, $box, $obj, $type, $param = array()) {
+
+	if ($type == "point") {
+		$reposition_obj = 
+			"var coords = $('#qn{$box}').val();
+			coords = coords.substring(1, coords.length - 2);
+			coords = coords.split(',');
+			{$obj}.setPosition(JXG.COORDS_BY_USER, [parseFloat(coords[0]),parseFloat(coords[1])]);";
+			
+	} else if ($type == "slider") {
+		
+		$min = $param[0];
+		$max = $param[1];
+		$reposition_obj = 
+			"var tc = $('#qn{$box}').val();
+			{$obj}.setGliderPosition(((tc)-({$min}))/(({$max})-({$min})));";
+	}
+
+	$out = 
+		"var colorInterval{$boardID}_{$box} = setInterval(function() {  
+			if ($('#qn{$box}')[0] || $('#qn{$box}')[0]) {
+				if ($('#qn{$box}, #tc{$box}').is('.ansgrn')) {
+					$('#jxgboard_{$boardID}').css('border', '1px solid #0f0');
+				} else if ($('#qn{$box}, #tc{$box}').is('.ansred') || $('#qn{$box}, #tc{$box}').is('.ansyel')) {
+					$('#jxgboard_{$boardID}').css('border','1px solid #f00');
+				}
+				/* Pull in answer from answerbox is possible */
+				if ($('#qn{$box}')[0] && $('#qn{$box}').val() !== '') {
+					{$reposition_obj}
+					board_{$boardID}.fullUpdate();
+				} else if ($('#tc{$box}')[0] && $('#tc{$box}').val() !== '') {
+					{$reposition_obj}
+					board_{$boardID}.fullUpdate();
+				}
+				clearInterval(colorInterval{$boardID}_{$box});
+			}
+		}, 300);";
+		
+	return $out;
+}
+
+?>

--- a/assessment/libs/jsxgraph.php
+++ b/assessment/libs/jsxgraph.php
@@ -1542,29 +1542,23 @@ function jsx_getscript () {
 				exp = exp.replaceAll(/\-\s*\-/g, "+");
 				exp = exp.replaceAll(/\+\s*\+/g, "+");
 				exp = exp.replaceAll(/\*\s*1(\D|$)/g, "$1"); // x*1 = x
-				console.log("1: " + exp);
 				exp = exp.replaceAll(/(\D|^)(1\s*\*|1\s*\**([a-zA-Z\(]))/g, "$1$3"); // 1*x = x
-				console.log("2: " + exp);
 				exp = exp.replaceAll(/(^|[\=\(\+\-])\s*(0\s*\*?)([a-zA-Z](\^[\-\d\.]+)*)/g, "$1"); //3+0x-4 -> 3-4
 				exp = exp.replaceAll(/\+\s*\-/g, "-");
 				exp = exp.replaceAll(/\-\s*\+/g, "-");
 				exp = exp.replaceAll(/\-\s*\-/g, "+");
 				exp = exp.replaceAll(/\+\s*\+/g, "+");
-				console.log("3: " + exp);
 				exp = exp.replaceAll(/(^|[\(])\s*0(\s*[\+\-\)])/g, "$1");  //0+x, 0-x
 				exp = exp.replaceAll(/\+\s*\-/g, "-");
 				exp = exp.replaceAll(/\-\s*\+/g, "-");
 				exp = exp.replaceAll(/\-\s*\-/g, "+");
 				exp = exp.replaceAll(/\+\s*\+/g, "+");
-				console.log("4: " + exp);
 				exp = exp.replaceAll(/[\+\-]\s*0(\)|\D|$)/g, "$1");  // x+0, x-0
 				exp = exp.replaceAll(/\+\s*\-/g, "-");
 				exp = exp.replaceAll(/\-\s*\+/g, "-");
 				exp = exp.replaceAll(/\-\s*\-/g, "+");
 				exp = exp.replaceAll(/\+\s*\+/g, "+");
-				console.log("5: " + exp);
 				exp = exp.replaceAll(/=\s*\+/g, "="); // =+2x -> =2x
-				console.log("6: " + exp);
 				exp = exp.replaceAll(/\+\s*\-/g, "-");
 				exp = exp.replaceAll(/\-\s*\+/g, "-");
 				exp = exp.replaceAll(/\-\s*\-/g, "+");	

--- a/assessment/libs/jsxgraph.php
+++ b/assessment/libs/jsxgraph.php
@@ -47,13 +47,8 @@ $allowedmacros[] = "jsxSuspendUpdate";
 $allowedmacros[] = "jsxUnsuspendUpdate";
 
 
-// next in line:
-// -- integral
-
-
 function jsx_getlibrarylink() {
-	return "//cdnjs.cloudflare.com/ajax/libs/jsxgraph/0.99.6/jsxgraphcore.js";
-	//return "//cdnjs.cloudflare.com/ajax/libs/jsxgraph/1.1.0/jsxgraphcore.js";
+	return "//cdn.jsdelivr.net/npm/jsxgraph@1.2.1/distrib/jsxgraphcore.js";
 }
 
 function jsx_idlen() {
@@ -1124,7 +1119,7 @@ function jsxText (&$board, $param, $ops=array()) {
 	$inputerror = false;
 
 	// Validate input values
-	if (is_jsxpoint($param[0]) && is_jsxvalue($param[1])) {
+	if (is_jsxpoint($param[0]) && (is_jsxvalue($param[1]) || is_array($param[1]))) {
 			
 		// Set default values
 		$fontsize = $ops['fontsize'] !== null ? $ops['fontsize'] : 16;
@@ -1134,8 +1129,6 @@ function jsxText (&$board, $param, $ops=array()) {
 		$anchor = $ops['anchor'] !== null ? $ops['anchor'] : false;
 		$anchorX = $ops['anchorX'] !== null ? $ops['anchorX'] : false;
 		$anchorY = $ops['anchorY'] !== null ? $ops['anchorY'] : false;
-		
-		$useMathJax = strpos($param[1], "`") > -1 ? 'true' : 'false';
 		
 		// Begin object creation
 
@@ -1147,16 +1140,60 @@ function jsxText (&$board, $param, $ops=array()) {
 			$out .= jsx_valueToJS("$param[0].X()").", ".jsx_valueToJS("$param[0].Y()").", ";
 		}
 		
-		if (count(jsx_getobjectreferences($param[1])) > 0) {
-			$out .= "function() { return {$param[1]}; }],";
-		} else {
-			$out .= "'{$param[1]}'],";
-		}
+		if (is_jsxvalue($param[1])) {
+			if (count(jsx_getobjectreferences($param[1])) > 0) {
+				$out .= "function() { return {$param[1]}; }],";
+			} else {
+				$out .= "'{$param[1]}'],";
+			}
+		} else if (is_array($param[1])) {
+			
+			$makepretty = false;
+			$display = false;
+			
+			for ($i = 1; $i < count($param[1]); $i++) {
+				
+				switch ($param[1][$i]) {
+					case 'makepretty' :	$makepretty = true;	break;
+					case 'display' : $display = true; break;
+					default:
+						echo "Warning: Unknown label rendering hint encountered: {$param[1][$i]}";
+				}
+				
+			}
+			
+			$label = $param[1][0];
+			
+			if ($label !== '') {
+
+				if ($makepretty && !$display) {
+					$out .= "function() { return jsx_clean({$label}); }],";
+				} 
+				
+				if (!$makepretty && $display) {
+					$out .= "function() { return '`' + {$label} + '`';  }],";
+				}
+				
+				if ($makepretty && $display) {
+					$out .= "function() { return '`' + jsx_clean({$label}) + '`';  }],";
+				}
+				
+				if (!$makepretty && !$display) {
+					if (count(jsx_getobjectreferences($label)) > 0) {
+						$out .= "function() { return {$label}; }],";
+					} else {
+						$out .= "'{$label}'],";
+					}
+				}
+
+			}
+		
+		} 
 
 		// Set attributes 
 		
 		$out .= "{";
-		$out .= "useMathJax: {$useMathJax},";
+		$out .= "useMathJax: 'true',";
 		$out .= "fontSize: {$fontsize},";
 		$out .= "highlight: {$highlight},";
 		$out .= "fixed: {$fixed},";
@@ -1498,7 +1535,49 @@ function jsx_getscript () {
 			jsxgloadscript.src = "'.jsx_getlibrarylink().'";
 			document.getElementsByTagName("head")[0].appendChild(jsxgloadscript);
 			JXGscriptloaded = true;
-			} </script>';
+			}
+			function jsx_clean(exp) {
+				exp = exp.replaceAll(/\+\s*\-/g, "-");
+				exp = exp.replaceAll(/\-\s*\+/g, "-");
+				exp = exp.replaceAll(/\-\s*\-/g, "+");
+				exp = exp.replaceAll(/\+\s*\+/g, "+");
+				exp = exp.replaceAll(/\*\s*1(\D|$)/g, "$1"); // x*1 = x
+				console.log("1: " + exp);
+				exp = exp.replaceAll(/(\D|^)(1\s*\*|1\s*\**([a-zA-Z\(]))/g, "$1$3"); // 1*x = x
+				console.log("2: " + exp);
+				exp = exp.replaceAll(/(^|[\=\(\+\-])\s*(0\s*\*?)([a-zA-Z](\^[\-\d\.]+)*)/g, "$1"); //3+0x-4 -> 3-4
+				exp = exp.replaceAll(/\+\s*\-/g, "-");
+				exp = exp.replaceAll(/\-\s*\+/g, "-");
+				exp = exp.replaceAll(/\-\s*\-/g, "+");
+				exp = exp.replaceAll(/\+\s*\+/g, "+");
+				console.log("3: " + exp);
+				exp = exp.replaceAll(/(^|[\(])\s*0(\s*[\+\-\)])/g, "$1");  //0+x, 0-x
+				exp = exp.replaceAll(/\+\s*\-/g, "-");
+				exp = exp.replaceAll(/\-\s*\+/g, "-");
+				exp = exp.replaceAll(/\-\s*\-/g, "+");
+				exp = exp.replaceAll(/\+\s*\+/g, "+");
+				console.log("4: " + exp);
+				exp = exp.replaceAll(/[\+\-]\s*0(\)|\D|$)/g, "$1");  // x+0, x-0
+				exp = exp.replaceAll(/\+\s*\-/g, "-");
+				exp = exp.replaceAll(/\-\s*\+/g, "-");
+				exp = exp.replaceAll(/\-\s*\-/g, "+");
+				exp = exp.replaceAll(/\+\s*\+/g, "+");
+				console.log("5: " + exp);
+				exp = exp.replaceAll(/=\s*\+/g, "="); // =+2x -> =2x
+				console.log("6: " + exp);
+				exp = exp.replaceAll(/\+\s*\-/g, "-");
+				exp = exp.replaceAll(/\-\s*\+/g, "-");
+				exp = exp.replaceAll(/\-\s*\-/g, "+");	
+				exp = exp.replaceAll(/\+\s*\+/g, "+");
+				if (exp[0] == "+") {
+					exp = exp.substring(1);
+					return exp == "" ? "0" : exp;
+				}
+				exp = exp.replaceAll(/^([a-zA-Z])\s*=\s*$/g,"$1=0");
+				return exp;
+
+			}
+			</script>';
 	}
 }
 
@@ -1598,10 +1677,19 @@ function jsx_createrectangularboard ($label, $ops = array()) {
 	$ymin = $ops['bounds'][2] !== null ? $ops['bounds'][2] : -5;
 	$ymax = $ops['bounds'][3] !== null ? $ops['bounds'][3] : 5;
 
-	$minorTicksX = $ops['minorticks'][0] !== null ? $ops['minorticks'][0] : 1;
-	$minorTicksY = $ops['minorticks'][1] !== null ? $ops['minorticks'][1] : 1;
+	$minorTicksX = $ops['minorticks'][0] !== null ? $ops['minorticks'][0] : 0;
+	$minorTicksY = $ops['minorticks'][1] !== null ? $ops['minorticks'][1] : 0;
 	$ticksDistanceX = $ops['ticksdistance'][0] !== null ? $ops['ticksdistance'][0] : floor((($xmax)-($xmin))/8);
 	$ticksDistanceY = $ops['ticksdistance'][1] !== null ? $ops['ticksdistance'][1] : floor((($ymax)-($ymin))/8);
+	
+	$showXLabels = $ops['showlabels'][0] !== null ? jsx_getbool($ops['showlabels'][0]) : 'true';
+	$showYLabels = $ops['showlabels'][1] !== null ? jsx_getbool($ops['showlabels'][1]) : 'true';
+	
+	$gridHeightX = $ops['gridheight'][0] !== null ? $ops['gridheight'][0] : -1;
+	$gridHeightY = $ops['gridheight'][1] !== null ? $ops['gridheight'][1] : -1;
+	
+	$minorTickHeightX = $ops['minortickheight'][0] !== null ? $ops['minortickheight'][0] : 10;
+	$minorTickHeightY = $ops['minortickheight'][1] !== null ? $ops['minortickheight'][1] : 10;
 
 	$useMathJax = ($ops['axislabel'] !== null && (strpos($ops['axislabel'][0], "`") > -1 || strpos($ops['axislabel'][1], "`") > -1)) ? "true" : "false";
 
@@ -1610,7 +1698,6 @@ function jsx_createrectangularboard ($label, $ops = array()) {
             curve: 5, turtle: 5, polygon: 3, sector: 3, angle: 3, integral: 3, axis: 3, ticks: 2, grid: 1, image: 0, trace: 0};";
    
 	// Create the board
-	$defaultAxis = $ops['ticksdistance'] ? "false" : "true";
 	$out .= "window.board_{$label} = JXG.JSXGraph.initBoard('jxgboard_{$label}', {
              boundingbox: [{$xmin}, {$ymax}, {$xmax}, {$ymin}],
              axis: false,
@@ -1630,29 +1717,36 @@ function jsx_createrectangularboard ($label, $ops = array()) {
 			 }
            });";
 
-	$out .= "var xTicks{$label}, yTicks{$label}, bb{$label};";
+	$out .= "var xTicks{$label}, yTicks{$label};";
    
 	// x-axis
 	$out .= "var xaxis{$label} = board_{$label}.create('axis', [[0,0], [1,0]], {
-               strokeColor:'black',
-               strokeWidth: 2,
-               highlight:false,
-               name:'" . ($ops['axislabel'][0] != null ? $ops['axislabel'][0] : "") . "',
-               withLabel:true,
-               label: {position:'rt', offset:[-15,15], highlight:false, useMathJax:{$useMathJax}}
-             });";
-	// Remove standard ticks and create new ones based off of tickDistance
-	$out .= "xaxis{$label}.removeAllTicks();";
-	$out .= "var xticks{$label} = board_{$label}.create('ticks',[xaxis{$label}], {
-             ticksDistance: {$ticksDistanceX},
-             strokeColor: 'rgba(150,150,150,0.85)',
-             majorHeight:-1,
-             minorHeight: -1,
-             highlight:false,
-             drawLabels:true,
-             label:{offset:[0,-5], anchorY:'top', anchorX:'middle', highlight:false},
-             minorTicks: {$minorTicksX}
-           });";
+				strokeColor:'black',
+				strokeWidth: 2,
+				highlight:false,
+				name:'" . ($ops['axislabel'][0] != null ? $ops['axislabel'][0] : "") . "',
+				label: { 
+					position: 'rt', 
+					offset: [-15,15], 
+					highlight: false, 
+					useMathJax: {$useMathJax}
+				},
+				ticks: {
+					insertTicks: false,
+					ticksDistance: $ticksDistanceX,
+					minorTicks: $minorTicksX,
+					majorHeight: $gridHeightX,
+					minorHeight: $minorTickHeightX,
+					color: 'black',
+					label: { 
+						offset: [0,-5], 
+						anchorY: 'top', 
+						anchorX: 'middle', 
+						highlight: false, 
+						visible: $showXLabels
+					}
+				} 
+            });";
 
 	// y-axis
 	$out .= "var yaxis{$label} = board_{$label}.create('axis', [[0,0],[0,1]], {
@@ -1661,49 +1755,23 @@ function jsx_createrectangularboard ($label, $ops = array()) {
                highlight:false,
                name:'" . ($ops['axislabel'][1] != null ? $ops['axislabel'][1] : "") . "',
                withLabel:true,
-               label: {position:'rt', offset:[10,-15], highlight:false, useMathJax:{$useMathJax}}
+               label: {position:'rt', offset:[10,-15], highlight:false, useMathJax:{$useMathJax}},
+			   ticks: {
+					insertTicks: false,
+					ticksDistance: $ticksDistanceY,
+					minorTicks: $minorTicksY,
+					majorHeight: $gridHeightY,
+					minorHeight: $minorTickHeightY,
+					label: {
+						offset: [-5,0],
+						anchorY: 'middle', 
+						anchorX: 'right', 
+						highlight: false,
+						visible: $showYLabels
+					}
+				} 
              });";
-	
-	// Remove standard ticks and create new ones based off of tickDistance
-    $out .= "yaxis{$label}.removeAllTicks();";
-    $out .= "var yticks{$label} = board_{$label}.create('ticks',[yaxis{$label}], {
-              ticksDistance: {$ticksDistanceY},
-              strokeColor: 'rgba(150,150,150,0.85)',
-              majorHeight:-1,
-              minorHeight: -1,
-              highlight:false,
-              drawLabels:true,
-              label:{offset:[-5, 0], anchorY:'middle', anchorX:'right', highlight:false},
-              minorTicks: {$minorTicksY}
-            });";
-
-    // If zoom is allowed, we need to make sure ticks behave nicely
-    if ($zoom == "true") {
-		$out .= "xticks{$label}.ticksFunction = function(){return xTicks{$label};};";
-		$out .= "yticks{$label}.ticksFunction = function(){return yTicks{$label};};";
-      
-		// Tick handling functions
-		$out .= "var setTicks{$label} = function(){
-          bb = board_{$label}.getBoundingBox();
-          xTicksVal = Math.pow(10, Math.floor((Math.log(0.6*(bb[2]-bb[0])))/Math.LN10));
-          if( (bb[2]-bb[0])/xTicksVal > 6) {
-        	  xTicks{$label} = xTicksVal;
-        	} else {
-        	  xTicks{$label} = 0.5* xTicksVal;
-        	}
-        	yTicksVal = Math.pow(10, Math.floor((Math.log(0.6*(bb[1]-bb[3])))/Math.LN10));
-        	if( (bb[1]-bb[3])/yTicksVal > 6) {
-        	  yTicks{$label} = yTicksVal;
-        	} else {
-        	  yTicks{$label} = 0.5* yTicksVal;
-        	}
-        	board_{$label}.fullUpdate(); // full update is required
-        };
-        setTicks{$label}();
-        board_{$label}.on('boundingbox', function(){setTicks{$label}();});
-        board_{$label}.fullUpdate();";
-    }
-    
+	  
 	$boardinit = jsx_setupboard($label, $width, $height, $centered);
     return substr_replace($boardinit, $out, strpos($boardinit, "/*INSERTHERE*/"), 0);
 
@@ -2201,21 +2269,77 @@ function jsx_getbool($bool) {
 
 
 // Affixes a label to a jsx object, sets it up so that it can be dynamic 
-// static
+// or static. A string for the label can be passed, or an array that
+// contains the label string along with some rendering hints. The possible
+// rendering hints are: makepretty, display, function.
+// makepretty will attempt to clean up things like 1 * x, x + 0, x + - 1
+// disp will make the label show up as a rendered math function
+// function will allow the user to provide a javascript function to
+//   allow for high levels of customization
 function jsx_setlabel($id, $label) {
 	
-	if($label !== '') {
-		if(strpos($label, 'this.') !== false) {
-			$label = str_replace('this', $id, $label);
-		}
+	$js = "{$id}.label.setText('');";
+	
+	if (is_string($label)) {
+		if ($label !== '') {
+			if (strpos($label, 'this.') !== false) {
+				$label = str_replace('this', $id, $label);
+			}
 
-		if (count(jsx_getobjectreferences($label)) > 0) {
-			$js = "{$id}.label.setText(function() { return {$label}; });";
-		} else {
-			$js = "{$id}.label.setText('{$label}');";
+			if (count(jsx_getobjectreferences($label)) > 0) {
+				$js = "{$id}.label.setText(function() { return {$label}; });";
+			} else {
+				$js = "{$id}.label.setText('{$label}');";
+			}
+		
+			return $js;
+		}
+	} else if (is_array($label)) {
+
+		$makepretty = false;
+		$display = false;
+		
+		for ($i = 1; $i < count($label); $i++) {
+			
+			switch ($label[$i]) {
+				case 'makepretty' :	$makepretty = true;	break;
+				case 'display' : $display = true; break;
+				default:
+					echo "Warning: Unknown label rendering hint encountered: {$label[$i]}";
+			}
+			
 		}
 		
-		return $js;
+		$label = $label[0];
+		
+		if ($label !== '') {
+			if (strpos($label, 'this.') !== false) {
+				$label = str_replace('this', $id, $label);
+			}
+
+			if ($makepretty && !$display) {
+				$js = "{$id}.label.setText(function() { return jsx_clean({$label}); });";
+			} 
+			
+			if (!$makepretty && $display) {
+				$js = "{$id}.label.setText(function() { return '`' + {$label} + '`';  });";
+			}
+			
+			if ($makepretty && $display) {
+				$js = "{$id}.label.setText(function() { return '`' + jsx_clean({$label}) + '`';  });";
+			}
+		
+			if (!$makepretty && !$display) {
+				if (count(jsx_getobjectreferences($label)) > 0) {
+					$js = "{$id}.label.setText(function() { return {$label}; });";
+				} else {
+					$js = "{$id}.label.setText('{$label}');";
+				}
+			}
+		
+			return $js;
+		}
+		
 	}
 }
 

--- a/assessment/libs/jsxgraph.php
+++ b/assessment/libs/jsxgraph.php
@@ -52,7 +52,8 @@ $allowedmacros[] = "jsxUnsuspendUpdate";
 
 
 function jsx_getlibrarylink() {
-	return "//cdnjs.cloudflare.com/ajax/libs/jsxgraph/1.1.0/jsxgraphcore.js";
+	return "//cdnjs.cloudflare.com/ajax/libs/jsxgraph/0.99.6/jsxgraphcore.js";
+	//return "//cdnjs.cloudflare.com/ajax/libs/jsxgraph/1.1.0/jsxgraphcore.js";
 }
 
 function jsx_idlen() {
@@ -1285,7 +1286,8 @@ function jsxFunction(&$board, $f, $ops=array()) {
   
 	$objects = jsx_getobjectreferences($f);
   
-	// Here we preserve the text of the function in case it is needed elswhere
+	// Here we preserve the text of the function so it can be used in other objects
+	// like Riemannsum
 	$out = "var {$id}_text = ".jsx_functionToJS($f, $inpVar).";";
   
 	// Start the output string
@@ -2181,7 +2183,7 @@ function jsx_functionToJS($rule, $var) {
 		}
 	}
 	$js .= "with (Math) var result = eval(mathjs(ts, '{$var}'));
-            return result; }";
+            return result; }"; 
 		
 	return $js;
 }


### PR DESCRIPTION
These are the update we discussed about jsxgraph along with a couple of others:

1. ticksdistance and minorticks were fixed and are now working as expected
2. majortickheight and minortickheight were added as new options to rectangular board
3. showlabels was added as a new option to rectangular boards to be able to turn of tick mark labels
4. ability to turn off the rectangular grid is enabled by setting majortickheight to zero
5. labels were extended to be able to be passed as arrays and contain rendering hints. These hints are: display - wraps the string in back-ticks for easier asciimath rendering, and makepretty - enables cleaning up of algebraic strings to look nicer when displayed