### PR TITLE
Removed Warning Message

### DIFF
--- a/assessment/libs/finderiv.php
+++ b/assessment/libs/finderiv.php
@@ -22,7 +22,7 @@ function finderiv_payout($asset, $types, $possizes, $strikes){
 		echo 'finderiv_payout: types must be an array';
 		return false;
     }
-    array_walk($types, 'strtolower');
+    $types = array_map('strtolower',$types);
 	$numTypes = count($types);
 	if ($numTypes>100) {
 		echo 'finderiv_payout: numTypes is too big. Capped at 100.';


### PR DESCRIPTION
I changed a line of code that was causing a warning message to appear in the function finderiv_payout. No functionality was changed.

In line 25 there was a array_walk function call with strtolower. The PHP documentation mentions that array_walk will cause this warning to appear. I modified the array_walk call to array_map which seems to resolve the issue.

thanks,

Daniel Brown