### PR TITLE
252 - fix php module error for gb => gd

### DIFF
--- a/install.php
+++ b/install.php
@@ -199,7 +199,7 @@ if (!extension_loaded("pdo_mysql")) {
 	echo '<p><b>Warning</b>:  It appears your PHP does not have the pdo_mysql extension installed, and it is required.</p>';
 }
 if (!function_exists('gd_info')) {
-	echo '<p><b>Warning</b>:  It appears your PHP does not have the gb extension installed, which is needed for some functionality.</p>';
+	echo '<p><b>Warning</b>:  It appears your PHP does not have the gd extension installed, which is needed for some functionality.</p>';
 }
 if (!function_exists('curl_init')) {
 	echo '<p><b>Warning</b>:  It appears your PHP does not have the curl extension installed, which is needed for some functionality.</p>';


### PR DESCRIPTION
Hi, I created a PR to fix the spelling error I found in the install.php language

Hope this helps save someone else 5 minutes realizing there is no php **GB** extension 🤦 

edit: apologies if I didn't follow correct tagging / merge target process for your project, I just wanted to jot down the fix quick before I forgot. lmk if I need to change anything.