### PR TITLE
fix to polygon and closedpolygon to allow identical, consecutive points

### DIFF
--- a/assess2/questions/scorepart/DrawingScorePart.php
+++ b/assess2/questions/scorepart/DrawingScorePart.php
@@ -152,6 +152,22 @@ class DrawingScorePart implements ScorePart
                 $pixy = $settings[7] - (evalbasic($function[1])-$settings[2])*$pixelspery - $imgborder;
                 $ansdots[$key] = array($pixx,$pixy);
             }
+            if (!empty($ansdots)) {
+              $deletekeys = [];
+              for ($i=0; $i<count($ansdots)-1; $i++) {
+                if (isset($ansdots[$i+1])) {
+                  if (comparenumbers($ansdots[$i][0],$ansdots[$i+1][0],1E-9) && comparenumbers($ansdots[$i][1],$ansdots[$i+1][1],1E-9)) {
+                    $deletekeys[] = $i;
+                  }
+                } 
+              }
+              if (!empty($deletekeys)) {
+                foreach ($deletekeys as $deletekey) {
+                  unset($ansdots[$deletekey]);
+                }
+                $ansdots = array_values($ansdots);
+              }
+            }
             $isclosed = false;
             $stuclosed = false;
             if (abs($ansdots[0][0]-$ansdots[count($ansdots)-1][0])<.01 && abs($ansdots[0][1]-$ansdots[count($ansdots)-1][1])<.01) {


### PR DESCRIPTION
When $answerformat = "polygon" or "closedpolygon", if the answer has any equal, consecutive points, they cannot be drawn, but they each count for points. Example:

$answers = array("1,1", "2,1", "2,2", "2,2", "1,1")
The point (2,2) cannot be drawn twice in a row, so full points cannot be earned.

This change tries to remove any equal, consecutive points from the answer.

[Note: This came to my attention when generating random polygonal regions, as in problem #742450.]