### PR TITLE
Add.gettwopointequation

### DIFF
--- a/assessment/macros.php
+++ b/assessment/macros.php
@@ -32,7 +32,7 @@ array_push($GLOBALS['allowedmacros'],"exp","sec","csc","cot","sech","csch","coth
  "getstuans","checkreqtimes","stringtopolyterms","getfeedbackbasic","getfeedbacktxt",
  "getfeedbacktxtessay","getfeedbacktxtnumber","getfeedbacktxtnumfunc",
  "getfeedbacktxtcalculated","explode","gettwopointlinedata","getdotsdata",
- "getopendotsdata","gettwopointdata","gettwopointequation","getlinesdata","getineqdata","adddrawcommand",
+ "getopendotsdata","gettwopointdata","gettwopointformulas","getlinesdata","getineqdata","adddrawcommand",
  "mergeplots","array_unique","ABarray","scoremultiorder","scorestring","randstate",
  "randstates","prettysmallnumber","makeprettynegative","rawurlencode","fractowords",
  "randcountry","randcountries","sorttwopointdata","addimageborder","formatcomplex",
@@ -4133,6 +4133,7 @@ function gettwopointdata($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=null,
       } else if ($type=='genexp' || $type=='genlog') {
         $pts[5] = ($pts[5] - $imgborder)/$pixelsperx + $xmin;
         $pts[6] = ($h - $pts[6] - $imgborder)/$pixelspery + $ymin;
+        // Last value is the asymptote: y val for genexp, x val for genlog
         $outpt = ($type=='genexp') ? array($pts[3], $pts[4], $pts[5], $pts[6], $pts[2]) : array($pts[3], $pts[4], $pts[5], $pts[6], $pts[1]);
       }
 			$outpts[] = $outpt;
@@ -4141,16 +4142,28 @@ function gettwopointdata($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=null,
 	return $outpts;
 }
 
-function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=null,$w=null,$h=null) {
+function gettwopointformulas($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=null,$w=null,$h=null) {
+  $args = func_get_args();
+  $eqnvars = [];
+  foreach ($args as $key => $arg) {
+    if (strpos($arg,'showequation') !== false) {
+      $showequation = true;
+      if (!is_array($args[$key])) {
+        $eqnvars = explode(",",$args[$key]);
+      }
+    }
+  }
+  $x = (!empty($eqnvars[1])) ? $eqnvars[1] : 'x';
+  $y = (!empty($eqnvars[2])) ? $eqnvars[2] : 'y';
   $pts = gettwopointdata($str,$type,$xmin,$xmax,$ymin,$ymax,$w,$h);
-  $numeqns = count($pts);
-  if (!empty($numeqns)) {
+  if (!empty($pts)) {
     if ($type=='line' || $type=='lineseg' || $type=='ray') {
   		foreach ($pts as $key => $pt) {
         if (abs($pt[0]-$pt[2]) > 1E-12) {
           $slope = ($pt[3]-$pt[1])/($pt[2]-$pt[0]);
           $int = $pt[1] - $slope*$pt[0];
-          $outeqs[] = makexxpretty("$slope x + $int");
+          $outexps[] = makexxpretty("$slope $x + $int");
+          $outeqs[] = makexxpretty("$y = $slope $x + $int");
         }
       }
   	} else if ($type=='parab') {
@@ -4159,7 +4172,8 @@ function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=n
           $k = ($pt[3]-$pt[1])/pow($pt[2]-$pt[0],2);
           $coef1 = -2*$pt[0]*$k;
           $coef2 = pow($pt[0],2)*$k + $pt[1];
-          $outeqs[] = makexxpretty("$k x^2 + $coef1 x + $coef2");
+          $outexps[] = makexxpretty("$k $x^2 + $coef1 $x + $coef2");
+          $outeqs[] = makexxpretty("$y = $k $x^2 + $coef1 $x + $coef2");
         }
       }
   	} else if ($type=='horizparab') {
@@ -4168,7 +4182,8 @@ function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=n
           $k = ($pt[2]-$pt[0])/pow($pt[3]-$pt[1],2);
           $coef1 = -2*$pt[1]*$k;
           $coef2 = pow($pt[1],2)*$k + $pt[0];
-          $outeqs[] = makexxpretty("$k y^2 + $coef1 y + $coef2");
+          $outexps[] = makexxpretty("$k $y^2 + $coef1 $y + $coef2");
+          $outeqs[] = makexxpretty("$x = $k $y^2 + $coef1 $y + $coef2");
         }
       }
   	} else if ($type=='cubic') {
@@ -4178,7 +4193,8 @@ function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=n
           $coef1 = -3*$pt[0]*$k;
           $coef2 = 3*pow($pt[0],2)*$k;
           $coef3 = -1*pow($pt[0],3)*$k+$pt[1];
-          $outeqs[] = makexxpretty("$k x^3 + $coef1 x^2 + $coef2 x + $coef3");
+          $outexps[] = makexxpretty("$k $x^3 + $coef1 $x^2 + $coef2 $x + $coef3");
+          $outeqs[] = makexxpretty("$y = $k $x^3 + $coef1 $x^2 + $coef2 $x + $coef3");
         }
       }
   	} else if ($type=='sqrt') {
@@ -4186,41 +4202,48 @@ function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=n
     		if (abs($pt[0]-$pt[2]) > 1E-12) {
           $k = ($pt[3]-$pt[1])/sqrt(abs($pt[2]-$pt[0]));
           $j = ($pt[2] > $pt[0]) ? 1 : -1;
-          $outeqs[] = makexxpretty("$k sqrt($j x - $pt[0]) + $pt[1]");
+          $outexps[] = makexxpretty("$k sqrt($j $x - $pt[0]) + $pt[1]");
+          $outeqs[] = makexxpretty("$y = $k sqrt($j $x - $pt[0]) + $pt[1]");
         }
       }
   	} else if ($type=='cuberoot') {
       foreach ($pts as $key => $pt) {
     		if (abs($pt[0]-$pt[2]) > 1E-12) {
-          $k = ($pt[3]-$pt[1])/pow($pt[2]-$pt[0],1/3);
-          $j = ($pt[2] > $pt[0]) ? 1 : -1;
-          $outeqs[] = makexxpretty("$k ($j x - $pt[0])^(1/3) + $pt[1]");
+          $k = abs($pt[3]-$pt[1])/pow(abs($pt[2]-$pt[0]),1/3);
+          $k *= (($pt[2]-$pt[0])*($pt[3]-$pt[1]) < 0) ? -1 : 1;
+          $outexps[] = makexxpretty("$k root(3)($x - $pt[0]) + $pt[1]");
+          $outeqs[] = makexxpretty("$y = $k root(3)($x - $pt[0]) + $pt[1]");
         }
       }
   	} else if ($type=='abs') {
       foreach ($pts as $key => $pt) {
     		if (abs($pt[0]-$pt[2]) > 1E-12) {
-          $k = ($pt[2] > $pt[0]) ? ($pt[3]-$pt[1])*($pt[2]-$pt[0]) : -1*($pt[3]-$pt[1])*($pt[2]-$pt[0]);
-          $outeqs[] = makexxpretty("$k abs(x - $pt[0]) + $pt[1]");
+          $k = ($pt[2] > $pt[0]) ? ($pt[3]-$pt[1])/($pt[2]-$pt[0]) : -1*($pt[3]-$pt[1])/($pt[2]-$pt[0]);
+          $outexps[] = makexxpretty("$k abs($x - $pt[0]) + $pt[1]");
+          $outeqs[] = makexxpretty("$y = $k abs($x - $pt[0]) + $pt[1]");
         }
       }
   	} else if ($type=='rational') {
       foreach ($pts as $key => $pt) {
     		if (abs($pt[0]-$pt[2]) > 1E-12 && abs($pt[1]-$pt[3]) > 1E-12) {
           $k = ($pt[3]-$pt[1])*($pt[2]-$pt[0]);
-          $outeqs[] = makexxpretty("$k/(x - $pt[0]) + $pt[1]");
+          $outexps[] = makexxpretty("$k/($x - $pt[0]) + $pt[1]");
+          $outeqs[] = makexxpretty("$y = $k/($x - $pt[0]) + $pt[1]");
         }
       }
   	} else if ($type=='exp') {
       foreach ($pts as $key => $pt) {
-    		if (abs($pt[0]-$pt[2]) > 1E-12 && $pt[1]*$pt[3] > 0) {
-          $k = pow($pt[3]/$pt[1],1/($pt[2]-$pt[0]));
-          $j = $pt[1]/pow($k,$pt[0]);
-        } else if (abs($pt[1]) <= 1E-12 && abs($pt[3]) < 1E-12) {
-          $j = 0;
-          $k = 1;
+        if ($pt[1]*$pt[3] > 0) {
+          if (abs($pt[0]-$pt[2]) > 1E-12) {
+            $k = pow($pt[3]/$pt[1],1/($pt[2]-$pt[0]));
+            $j = $pt[1]/pow($k,$pt[0]);
+          } 
+          $outexps[] = ($pt[3]==$pt[1]) ? $pt[1] : makexxpretty("$j($k)^$x");
+          $outeqs[] = ($pt[3]==$pt[1]) ? "$y = $pt[1]" : makexxpretty("$y = $j($k)^$x");
+        } else if ($pt[1] == 0 && $pt[3] == 0) {
+          $outexps[] = 0;
+          $outeqs[] = "$y = 0";
         }
-          $outeqs[] = makexxpretty("$j($k)^x");
       }
   	} else if ($type=='log') {
       foreach ($pts as $key => $pt) {
@@ -4228,23 +4251,27 @@ function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=n
           $j = abs($pt[0])/$pt[0];
           $k = ($pt[3]-$pt[1])/(log($j*$pt[2])-log($j*$pt[0]));
           $b = $pt[1]-$k*log($j*$pt[0]);
-          $outeqs[] = makexxpretty("$k ln($j x) + $b");
+          $outexps[] = makexxpretty("$k ln($j $x) + $b");
+          $outeqs[] = makexxpretty("$y = $k ln($j $x) + $b");
         }
       }
   	} else if ($type=='genexp') {
       foreach ($pts as $key => $pt) {
-        if (abs($pt[1]-$pt[3]) < 1E-12 && abs($pt[3]-$pt[4]) < 1E-12) {
-          $outeq = "$pt[1]";
-        }
-        if (($pt[1]-$pt[4])*($pt[3]-$pt[4]) > 0 && abs($pt[0]-$pt[2]) > 1E-12) {
+        if (abs($pt[1]-$pt[3]) < 1E-12) {
+          $outexp = "$pt[1]";
+          $outeq = "$y = $pt[1]";
+        } else if (($pt[1]-$pt[4])*($pt[3]-$pt[4]) > 0 && abs($pt[0]-$pt[2]) > 1E-12) {
           if (abs($pt[1]-$pt[3]) > 1E-12) {
             $b = pow(($pt[3]-$pt[4])/($pt[1]-$pt[4]),1/($pt[2]-$pt[0]));
             $a = ($pt[3]-$pt[1])/(pow($b,$pt[2])-pow($b,$pt[0]));
           } elseif (abs($pt[1]-$pt[3]) <= 1E-12) {
-            $outeq = "$pt[1]";
+            $outexp = "$pt[1]";
+            $outeq = "$y = $pt[1]";
           }
-          $outeq = makexxpretty("$a($b)^x + $pt[4]");
+          $outexp = makexxpretty("$a($b)^$x + $pt[4]");
+          $outeq = "$y=".$outexp;
         }
+        $outexps[] = $outexp;
         $outeqs[] = $outeq;
       }
   	} else if ($type=='genlog') {
@@ -4254,16 +4281,19 @@ function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=n
           $b = $pt[1] - $a*log(abs($pt[0]-$pt[4]));
           $j = ($pt[0] > $pt[4]) ? 1 : -1;
           $shift = $pt[4]*$j;
-          $outeq = makexxpretty("$a ln($j x - $shift) + $b");
+          $outexp = makexxpretty("$a ln($j $x - $shift) + $b");
+          $outeq = "$y=".$outexp;
         }
+        $outexps[] = $outexp;
         $outeqs[] = $outeq;
       }
   	} else if ($type=='circle') {
       foreach ($pts as $key => $pt) {
     		if (!(abs($pt[0]-$pt[2]) < 1E-12 && abs($pt[1]-$pt[3]) < 1E-12)) {
           $rs = pow($pt[2]-$pt[0],2) + pow($pt[3]-$pt[1],2);
-          $xexp = ($pt[0]==0) ? "x^2" : "(x-$pt[0])^2";
-          $yexp = ($pt[1]==0) ? "y^2" : "(y-$pt[1])^2";
+          $xexp = ($pt[0]==0) ? "$x^2" : "($x-$pt[0])^2";
+          $yexp = ($pt[1]==0) ? "$y^2" : "($y-$pt[1])^2";
+          $outexps[] = makexxpretty("$xexp/$rs + $yexp/$rs");
           $outeqs[] = makexxpretty("$xexp + $yexp = $rs");
         }
       }
@@ -4272,8 +4302,9 @@ function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=n
     		if (abs($pt[0]-$pt[2]) > 1E-12 && abs($pt[1]-$pt[3]) > 1E-12) {
           $as = pow($pt[2]-$pt[0],2);
           $bs = pow($pt[3]-$pt[1],2);
-          $xexp = ($pt[0]==0) ? "x^2/$as" : "(x-$pt[0])^2/$as";
-          $yexp = ($pt[1]==0) ? "y^2/$bs" : "(y-$pt[1])^2/$bs";
+          $xexp = ($pt[0]==0) ? "$x^2/$as" : "($x-$pt[0])^2/$as";
+          $yexp = ($pt[1]==0) ? "$y^2/$bs" : "($y-$pt[1])^2/$bs";
+          $outexps[] = makexxpretty("$xexp + $yexp");
           $outeqs[] = makexxpretty("$xexp + $yexp = 1");
         }
       }
@@ -4285,11 +4316,15 @@ function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=n
             $b = M_PI/(2*abs($pt[2]-$pt[0]));
             $c = $pt[1];
             $shift = (($pt[1]-$pt[3])*($pt[0]-$pt[2]) > 0) ? fmod($pt[0]*$b,2*M_PI) : fmod((2*$pt[2]-$pt[0])*$b,2*M_PI);
-            $outeqs[] = makexxpretty("$a sin($b x - $shift) + $c");
+            $outexp = makexxpretty("$a sin($b $x - $shift) + $c");
+            $outeq = "$y=".$outexp;
           } else if (abs($pt[1]-$pt[3]) <= 1E-12) {
-            $outeqs[] = $pt[1];
+            $outexp = $pt[1];
+            $outeq = "$y = $pt[1]";
           }
         }
+        $outexps[] = $outexp;
+        $outeqs[] = $outeq;
       }
   	} else if ($type=='cos') {
       foreach ($pts as $key => $pt) {
@@ -4299,15 +4334,23 @@ function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=n
             $b = M_PI/abs($pt[2]-$pt[0]);
             $c = ($pt[1] + $pt[3])/2;
             $shift = ($pt[1] > $pt[3]) ? fmod($pt[0]*$b,2*M_PI) : fmod($pt[2]*$b,2*M_PI);
-            $outeqs[] = makexxpretty("$a cos($b x - $shift) + $c");
+            $outexp = makexxpretty("$a cos($b $x - $shift) + $c");
+            $outeq = "$y=".$outexp;
           } else if (abs($pt[1]-$pt[3]) <= 1E-12) {
-            $outeqs[] = $pt[1];
+            $outexp = $pt[1];
+            $outeq = "$y=$pt[1]";
           }
         }
       }
+      $outexps[] = $outexp;
+      $outeqs[] = $outeq;
   	}
   }
-  return $outeqs;
+  if ($showequation === true) {
+    return $outeqs;
+  } else {
+    return $outexps;  
+  }
 }
 
 function getineqdata($str,$type='linear',$xmin=null,$xmax=null,$ymin=null,$ymax=null,$w=null,$h=null) {

--- a/assessment/macros.php
+++ b/assessment/macros.php
@@ -32,7 +32,7 @@ array_push($GLOBALS['allowedmacros'],"exp","sec","csc","cot","sech","csch","coth
  "getstuans","checkreqtimes","stringtopolyterms","getfeedbackbasic","getfeedbacktxt",
  "getfeedbacktxtessay","getfeedbacktxtnumber","getfeedbacktxtnumfunc",
  "getfeedbacktxtcalculated","explode","gettwopointlinedata","getdotsdata",
- "getopendotsdata","gettwopointdata","getlinesdata","getineqdata","adddrawcommand",
+ "getopendotsdata","gettwopointdata","gettwopointequation","getlinesdata","getineqdata","adddrawcommand",
  "mergeplots","array_unique","ABarray","scoremultiorder","scorestring","randstate",
  "randstates","prettysmallnumber","makeprettynegative","rawurlencode","fractowords",
  "randcountry","randcountries","sorttwopointdata","addimageborder","formatcomplex",
@@ -4091,7 +4091,11 @@ function gettwopointdata($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=null,
 		$code = 8.3;
 	} else if ($type=='log') {
 		$code = 8.4;
-	} else if ($type=='circle' || $type=='circlerad') {
+	} else if ($type=='genexp') {
+    $code = 8.5;
+  } else if ($type=='genlog') {
+    $code = 8.6;
+  } else if ($type=='circle' || $type=='circlerad') {
 		$code = 7;
 	} else if ($type=='ellipse' || $type=='ellipserad') {
     $code = 7.2;
@@ -4118,17 +4122,192 @@ function gettwopointdata($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=null,
 			$pts[3] = ($pts[3] - $imgborder)/$pixelsperx + $xmin;
 			$pts[2] = ($h - $pts[2] - $imgborder)/$pixelspery + $ymin;
 			$pts[4] = ($h - $pts[4] - $imgborder)/$pixelspery + $ymin;
+      $outpt = array($pts[1], $pts[2], $pts[3], $pts[4]);
       if ($type=='ellipserad') {
         $pts[3] = abs($pts[3]-$pts[1]);
         $pts[4] = abs($pts[4]-$pts[2]);
+        $outpt = array($pts[1], $pts[2], $pts[3], $pts[4]);
       } else if ($type=='circlerad') {
         $pts[3] = sqrt(pow($pts[3]-$pts[1],2)+pow($pts[4]-$pts[2],2));
-        unset($pts[4]);
+        $outpt = array($pts[1], $pts[2], $pts[3]);
+      } else if ($type=='genexp' || $type=='genlog') {
+        $pts[5] = ($pts[5] - $imgborder)/$pixelsperx + $xmin;
+        $pts[6] = ($h - $pts[6] - $imgborder)/$pixelspery + $ymin;
+        $outpt = ($type=='genexp') ? array($pts[3], $pts[4], $pts[5], $pts[6], $pts[2]) : array($pts[3], $pts[4], $pts[5], $pts[6], $pts[1]);
       }
-			$outpts[] = array($pts[1], $pts[2], $pts[3], $pts[4]);
+			$outpts[] = $outpt;
 		}
 	}
 	return $outpts;
+}
+
+function gettwopointequation($str,$type,$xmin=null,$xmax=null,$ymin=null,$ymax=null,$w=null,$h=null) {
+  $pts = gettwopointdata($str,$type,$xmin,$xmax,$ymin,$ymax,$w,$h);
+  $numeqns = count($pts);
+  if (!empty($numeqns)) {
+    if ($type=='line' || $type=='lineseg' || $type=='ray') {
+  		foreach ($pts as $key => $pt) {
+        if (abs($pt[0]-$pt[2]) > 1E-12) {
+          $slope = ($pt[3]-$pt[1])/($pt[2]-$pt[0]);
+          $int = $pt[1] - $slope*$pt[0];
+          $outeqs[] = makexxpretty("$slope x + $int");
+        }
+      }
+  	} else if ($type=='parab') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12) {
+          $k = ($pt[3]-$pt[1])/pow($pt[2]-$pt[0],2);
+          $coef1 = -2*$pt[0]*$k;
+          $coef2 = pow($pt[0],2)*$k + $pt[1];
+          $outeqs[] = makexxpretty("$k x^2 + $coef1 x + $coef2");
+        }
+      }
+  	} else if ($type=='horizparab') {
+  		foreach ($pts as $key => $pt) {
+        if (abs($pt[1]-$pt[3]) > 1E-12) {
+          $k = ($pt[2]-$pt[0])/pow($pt[3]-$pt[1],2);
+          $coef1 = -2*$pt[1]*$k;
+          $coef2 = pow($pt[1],2)*$k + $pt[0];
+          $outeqs[] = makexxpretty("$k y^2 + $coef1 y + $coef2");
+        }
+      }
+  	} else if ($type=='cubic') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12) {
+          $k = ($pt[3]-$pt[1])/pow($pt[2]-$pt[0],3);
+          $coef1 = -3*$pt[0]*$k;
+          $coef2 = 3*pow($pt[0],2)*$k;
+          $coef3 = -1*pow($pt[0],3)*$k+$pt[1];
+          $outeqs[] = makexxpretty("$k x^3 + $coef1 x^2 + $coef2 x + $coef3");
+        }
+      }
+  	} else if ($type=='sqrt') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12) {
+          $k = ($pt[3]-$pt[1])/sqrt(abs($pt[2]-$pt[0]));
+          $j = ($pt[2] > $pt[0]) ? 1 : -1;
+          $outeqs[] = makexxpretty("$k sqrt($j x - $pt[0]) + $pt[1]");
+        }
+      }
+  	} else if ($type=='cuberoot') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12) {
+          $k = ($pt[3]-$pt[1])/pow($pt[2]-$pt[0],1/3);
+          $j = ($pt[2] > $pt[0]) ? 1 : -1;
+          $outeqs[] = makexxpretty("$k ($j x - $pt[0])^(1/3) + $pt[1]");
+        }
+      }
+  	} else if ($type=='abs') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12) {
+          $k = ($pt[2] > $pt[0]) ? ($pt[3]-$pt[1])*($pt[2]-$pt[0]) : -1*($pt[3]-$pt[1])*($pt[2]-$pt[0]);
+          $outeqs[] = makexxpretty("$k abs(x - $pt[0]) + $pt[1]");
+        }
+      }
+  	} else if ($type=='rational') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12 && abs($pt[1]-$pt[3]) > 1E-12) {
+          $k = ($pt[3]-$pt[1])*($pt[2]-$pt[0]);
+          $outeqs[] = makexxpretty("$k/(x - $pt[0]) + $pt[1]");
+        }
+      }
+  	} else if ($type=='exp') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12 && $pt[1]*$pt[3] > 0) {
+          $k = pow($pt[3]/$pt[1],1/($pt[2]-$pt[0]));
+          $j = $pt[1]/pow($k,$pt[0]);
+        } else if (abs($pt[1]) <= 1E-12 && abs($pt[3]) < 1E-12) {
+          $j = 0;
+          $k = 1;
+        }
+          $outeqs[] = makexxpretty("$j($k)^x");
+      }
+  	} else if ($type=='log') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12 && abs($pt[1]-$pt[3]) > 1E-12 && $pt[0]*$pt[2] > 0) {
+          $j = abs($pt[0])/$pt[0];
+          $k = ($pt[3]-$pt[1])/(log($j*$pt[2])-log($j*$pt[0]));
+          $b = $pt[1]-$k*log($j*$pt[0]);
+          $outeqs[] = makexxpretty("$k ln($j x) + $b");
+        }
+      }
+  	} else if ($type=='genexp') {
+      foreach ($pts as $key => $pt) {
+        if (abs($pt[1]-$pt[3]) < 1E-12 && abs($pt[3]-$pt[4]) < 1E-12) {
+          $outeq = "$pt[1]";
+        }
+        if (($pt[1]-$pt[4])*($pt[3]-$pt[4]) > 0 && abs($pt[0]-$pt[2]) > 1E-12) {
+          if (abs($pt[1]-$pt[3]) > 1E-12) {
+            $b = pow(($pt[3]-$pt[4])/($pt[1]-$pt[4]),1/($pt[2]-$pt[0]));
+            $a = ($pt[3]-$pt[1])/(pow($b,$pt[2])-pow($b,$pt[0]));
+          } elseif (abs($pt[1]-$pt[3]) <= 1E-12) {
+            $outeq = "$pt[1]";
+          }
+          $outeq = makexxpretty("$a($b)^x + $pt[4]");
+        }
+        $outeqs[] = $outeq;
+      }
+  	} else if ($type=='genlog') {
+      foreach ($pts as $key => $pt) {
+        if (($pt[0]-$pt[4])*($pt[2]-$pt[4]) > 0 && abs($pt[0]-$pt[2]) > 1E-12 && abs($pt[1]-$pt[3]) > 1E-12) {
+          $a = ($pt[3]-$pt[1])/(log(abs($pt[2]-$pt[4]))-log(abs($pt[0]-$pt[4])));
+          $b = $pt[1] - $a*log(abs($pt[0]-$pt[4]));
+          $j = ($pt[0] > $pt[4]) ? 1 : -1;
+          $shift = $pt[4]*$j;
+          $outeq = makexxpretty("$a ln($j x - $shift) + $b");
+        }
+        $outeqs[] = $outeq;
+      }
+  	} else if ($type=='circle') {
+      foreach ($pts as $key => $pt) {
+    		if (!(abs($pt[0]-$pt[2]) < 1E-12 && abs($pt[1]-$pt[3]) < 1E-12)) {
+          $rs = pow($pt[2]-$pt[0],2) + pow($pt[3]-$pt[1],2);
+          $xexp = ($pt[0]==0) ? "x^2" : "(x-$pt[0])^2";
+          $yexp = ($pt[1]==0) ? "y^2" : "(y-$pt[1])^2";
+          $outeqs[] = makexxpretty("$xexp + $yexp = $rs");
+        }
+      }
+  	} else if ($type=='ellipse') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12 && abs($pt[1]-$pt[3]) > 1E-12) {
+          $as = pow($pt[2]-$pt[0],2);
+          $bs = pow($pt[3]-$pt[1],2);
+          $xexp = ($pt[0]==0) ? "x^2/$as" : "(x-$pt[0])^2/$as";
+          $yexp = ($pt[1]==0) ? "y^2/$bs" : "(y-$pt[1])^2/$bs";
+          $outeqs[] = makexxpretty("$xexp + $yexp = 1");
+        }
+      }
+    } else if ($type=='sin') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12) {
+          if (abs($pt[1]-$pt[3]) > 1E-12) {
+            $a = abs($pt[3]-$pt[1]);
+            $b = M_PI/(2*abs($pt[2]-$pt[0]));
+            $c = $pt[1];
+            $shift = (($pt[1]-$pt[3])*($pt[0]-$pt[2]) > 0) ? fmod($pt[0]*$b,2*M_PI) : fmod((2*$pt[2]-$pt[0])*$b,2*M_PI);
+            $outeqs[] = makexxpretty("$a sin($b x - $shift) + $c");
+          } else if (abs($pt[1]-$pt[3]) <= 1E-12) {
+            $outeqs[] = $pt[1];
+          }
+        }
+      }
+  	} else if ($type=='cos') {
+      foreach ($pts as $key => $pt) {
+    		if (abs($pt[0]-$pt[2]) > 1E-12) {
+          if (abs($pt[1]-$pt[3]) > 1E-12) {
+            $a = abs($pt[3]-$pt[1])/2;
+            $b = M_PI/abs($pt[2]-$pt[0]);
+            $c = ($pt[1] + $pt[3])/2;
+            $shift = ($pt[1] > $pt[3]) ? fmod($pt[0]*$b,2*M_PI) : fmod($pt[2]*$b,2*M_PI);
+            $outeqs[] = makexxpretty("$a cos($b x - $shift) + $c");
+          } else if (abs($pt[1]-$pt[3]) <= 1E-12) {
+            $outeqs[] = $pt[1];
+          }
+        }
+      }
+  	}
+  }
+  return $outeqs;
 }
 
 function getineqdata($str,$type='linear',$xmin=null,$xmax=null,$ymin=null,$ymax=null,$w=null,$h=null) {

--- a/help.html
+++ b/help.html
@@ -2355,9 +2355,12 @@ The following macros create graphs or tables:
   of the two points used.</li>
 <li><strong>gettwopointdata(stuans, type, [xmin, xmax, ymin, ymax, drawing width, drawing height]) or gettwopointdata(stuans, type, [grid, snaptogrid])</strong>:  Takes a $stuanswers from a drawing question
   and pulls out the two-point data for the given curve type.  Type should be one of 'line', 'lineseg', 'ray', 'parab', 'horizparab', 'sqrt', 'cubic', 'cuberoot',
-  'rational', 'exp', 'log', 'sin', 'cos', 'abs', 'vector', 'circle','ellipse'.  Returns an array of curve data, each of form array(x1,y1,x2,y2) giving the coordinates of
+  'rational', 'exp', 'genexp', 'log', 'genlog', 'sin', 'cos', 'abs', 'vector', 'circle','ellipse'.  Returns an array of curve data, each of form array(x1,y1,x2,y2) giving the coordinates of
   the two points used.  They are returned in the order clicked.  For example, with 'parab' type, the first point is the vertex and the
-  second point is an arbitrary point. Can use type 'circlerad' to return array(x-center,y-center,radius) or 'ellipserad' to return array(x-center,y-center,x-radius,y-radius).</li>
+  second point is an arbitrary point. Using 'genexp' or 'genlog' will return a 5th entry which is the value of the asymptote. Can use type 'circlerad' to return array(x-center,y-center,radius) or 'ellipserad' to return array(x-center,y-center,x-radius,y-radius).</li>
+<li><strong>gettwopointequation(stuans, type, [xmin, xmax, ymin, ymax, drawing width, drawing height]) or gettwopointequation(stuans, type, [grid, snaptogrid])</strong>:  Takes a $stuanswers from a drawing question
+  and returns a formula for the given curve type.  Type should be one of 'line', 'lineseg', 'ray', 'parab', 'horizparab', 'sqrt', 'cubic', 'cuberoot',
+  'rational', 'exp', 'genexp', 'log', 'genlog', 'sin', 'cos', 'abs', 'circle','ellipse'.  Returns an array of expressions, each a function of x, for the curves drawn. They are returned in the order clicked.  For 'horizparab', output will be in terms of y. For 'circle' and 'ellipse', output will be equations in x and y.</li>
 <li><strong>getdotsdata(stuans, [xmin, xmax, ymin, ymax, drawing width, drawing height]) or getdotsdata(stuans, [grid, snaptogrid])</strong>:  Takes a $stuanswers from a drawing
   question and pulls out the closed dots data.  Returns an array of dots, each of form array(x1,y1) giving the coordinates
   of the dot.</li>

--- a/help.html
+++ b/help.html
@@ -2357,10 +2357,13 @@ The following macros create graphs or tables:
   and pulls out the two-point data for the given curve type.  Type should be one of 'line', 'lineseg', 'ray', 'parab', 'horizparab', 'sqrt', 'cubic', 'cuberoot',
   'rational', 'exp', 'genexp', 'log', 'genlog', 'sin', 'cos', 'abs', 'vector', 'circle','ellipse'.  Returns an array of curve data, each of form array(x1,y1,x2,y2) giving the coordinates of
   the two points used.  They are returned in the order clicked.  For example, with 'parab' type, the first point is the vertex and the
-  second point is an arbitrary point. Using 'genexp' or 'genlog' will return a 5th entry which is the value of the asymptote. Can use type 'circlerad' to return array(x-center,y-center,radius) or 'ellipserad' to return array(x-center,y-center,x-radius,y-radius).</li>
-<li><strong>gettwopointequation(stuans, type, [xmin, xmax, ymin, ymax, drawing width, drawing height]) or gettwopointequation(stuans, type, [grid, snaptogrid])</strong>:  Takes a $stuanswers from a drawing question
-  and returns a formula for the given curve type.  Type should be one of 'line', 'lineseg', 'ray', 'parab', 'horizparab', 'sqrt', 'cubic', 'cuberoot',
-  'rational', 'exp', 'genexp', 'log', 'genlog', 'sin', 'cos', 'abs', 'circle','ellipse'.  Returns an array of expressions, each a function of x, for the curves drawn. They are returned in the order clicked.  For 'horizparab', output will be in terms of y. For 'circle' and 'ellipse', output will be equations in x and y.</li>
+  second point is an arbitrary point. Using 'genexp' or 'genlog' will return a 5th entry which is the value of the asymptote. Can use type 'circlerad' to return array(x-center,y-center,radius) or 'ellipserad' 
+	to return array(x-center,y-center,x-radius,y-radius).</li>
+<li><strong>gettwopointformulas(stuans, type, [xmin, xmax, ymin, ymax, drawing width, drawing height]) or gettwopointformulas(stuans, type, [grid, snaptogrid])</strong>:  Takes a $stuanswers from a drawing question
+  and returns formulas for curves drawn by the student.  Type should be one of 'line', 'lineseg', 'ray', 'parab', 'horizparab', 'sqrt', 'cubic', 'cuberoot',
+  'rational', 'exp', 'genexp', 'log', 'genlog', 'sin', 'cos', 'abs', 'circle','ellipse'.  Returns an array of expressions, each a function of x, for the curves drawn. They are returned in the order clicked.  For 
+	'horizparab', output will be in terms of y. For 'circle' and 'ellipse', output will be expression in x and y equaling 1. Can give a final optional argument 'showequation,[xvar,yvar]' to output implicit equations with optional custom x 
+	and y variables.</li>
 <li><strong>getdotsdata(stuans, [xmin, xmax, ymin, ymax, drawing width, drawing height]) or getdotsdata(stuans, [grid, snaptogrid])</strong>:  Takes a $stuanswers from a drawing
   question and pulls out the closed dots data.  Returns an array of dots, each of form array(x1,y1) giving the coordinates
   of the dot.</li>


### PR DESCRIPTION
Adds a gettwopointformulas() macro for outputting formulas of curves drawn by students. [Also adds support for 'genexp' and 'genlog' in the gettwopointdata() macro.]

Default output is an expression in x for each function curve. [Exceptions are 'horizparab', where the output is an expression in y, and 'circle' and 'ellipse' where the output is an expression in x and y that equals 1.] Degenerate cases are given simplified formulas, such as a parabola that is drawn as a horizontal line.

There is an option for 'showequation,xvar,yvar' that will output equations instead of expressions, and custom variables can be used.