### PR TITLE
fixed conversions for cmH2O and psi

### DIFF
--- a/assessment/libs/units.php
+++ b/assessment/libs/units.php
@@ -211,10 +211,10 @@ function parseunits($unitsExpression) {
       'kPa' => [1000,array(1,-1,-2,0,0,0,0,0,0,0)], //kilopascal
       'MPa' => [1E6,array(1,-1,-2,0,0,0,0,0,0,0)], //megapascal
       'GPa' => [1E9,array(1,-1,-2,0,0,0,0,0,0,0)], //gigapascal
-      'atm' => [1.01E5,array(1,-1,-2,0,0,0,0,0,0,0)],
-      'atms' => [1.01E5,array(1,-1,-2,0,0,0,0,0,0,0)],
-      'atmosphere' => [1.01E5,array(1,-1,-2,0,0,0,0,0,0,0)],
-      'atmospheres' => [1.01E5,array(1,-1,-2,0,0,0,0,0,0,0)],
+      'atm' => [1.01325E5,array(1,-1,-2,0,0,0,0,0,0,0)],
+      'atms' => [1.01325E5,array(1,-1,-2,0,0,0,0,0,0,0)],
+      'atmosphere' => [1.01325E5,array(1,-1,-2,0,0,0,0,0,0,0)],
+      'atmospheres' => [1.01325E5,array(1,-1,-2,0,0,0,0,0,0,0)],
       'bar' => [100000,array(1,-1,-2,0,0,0,0,0,0,0)],
       'bars' => [100000,array(1,-1,-2,0,0,0,0,0,0,0)],
       'barometer' => [100000,array(1,-1,-2,0,0,0,0,0,0,0)],
@@ -224,8 +224,8 @@ function parseunits($unitsExpression) {
       'Torr' => [133.322,array(1,-1,-2,0,0,0,0,0,0,0)],
       'torr' => [133.322,array(1,-1,-2,0,0,0,0,0,0,0)],
       'mmHg' => [133.322,array(1,-1,-2,0,0,0,0,0,0,0)],
-      'cmWater' => [98.0638,array(1,-1,-2,0,0,0,0,0,0,0)], //This comes from a cmH2O preg_replace
-      'psi' => [98.0638,array(1,-1,-2,0,0,0,0,0,0,0)],
+      'cmWater' => [98.0665,array(1,-1,-2,0,0,0,0,0,0,0)], //This comes from a cmH2O preg_replace
+      'psi' => [6894.76,array(1,-1,-2,0,0,0,0,0,0,0)],
     //Electrical Units
       'C' => [1,array(0,0,1,0,0,0,0,0,1,0)],
       'Coulomb' => [1,array(0,0,1,0,0,0,0,0,1,0)],


### PR DESCRIPTION
I noticed some conversions were wrong and fixed them:
[1 atm](https://www.google.com/search?q=convert+1+atm+to+pascal&client=firefox-b-1-d&channel=tus5&sxsrf=AOaemvKbxAcb1ljG9gomnBwQRhezCdf8cA%3A1631569123294&ei=48Q_Ybu2Ed389APly6awCA&oq=convert+1+atm+to+pascal&gs_lcp=Cgdnd3Mtd2l6EAMyBQgAEIAEMggIABAIEAcQHjIFCAAQhgMyBQgAEIYDMgUIABCGAzoHCAAQRxCwAzoGCAAQBxAeSgUIPBIBMkoECEEYAFD0oQFY6aMBYNalAWgCcAJ4AIABigGIAbUCkgEDMi4xmAEAoAEByAEIwAEB&sclient=gws-wiz&ved=0ahUKEwj7s5TQ9PzyAhVdPn0KHeWlCYYQ4dUDCA0&uact=5)
[1 cm H2O](https://www.google.com/search?q=convert+1+cm+water+to+pascal&client=firefox-b-1-d&channel=tus5&sxsrf=AOaemvJgZ0nNWN0TswEfWVJXy3J8zibFOQ%3A1631569145747&ei=-cQ_YcWCLbS90PEP4b29sAU&oq=convert+1+cm+water+to+pascal&gs_lcp=Cgdnd3Mtd2l6EAM6BwgAEEcQsAM6CAgAEAgQBxAeOgYIABAIEB5KBQg8EgEzSgQIQRgAUMyaAlifoQJg0KICaANwAngAgAFdiAG_BJIBATiYAQCgAQHIAQjAAQE&sclient=gws-wiz&ved=0ahUKEwiF4-7a9PzyAhW0HjQIHeFeD1YQ4dUDCA0&uact=5)
[1 psi](https://www.google.com/search?q=convert+1+psi+to+pascal&client=firefox-b-1-d&channel=tus5&sxsrf=AOaemvKeYeEaYXDFvWy-yoVwrKN-Kw9unQ%3A1631568746044&ei=asM_YZGPAtDN0PEPv4WGkAU)