### PR TITLE
Adds option for bar over last non-terminating, significant zero

### DIFF
--- a/assessment/macros.php
+++ b/assessment/macros.php
@@ -1990,7 +1990,7 @@ function roundsigfig($val, $sigfig) {
 	return round($val, $sigfig - $log - 1);
 }
 
-function prettysigfig($aarr,$sigfig,$comma=',',$choptrailing=false,$orscinot=false) {
+function prettysigfig($aarr,$sigfig,$comma=',',$choptrailing=false,$orscinot=false,$sigfigbar=false) {
 	if (!is_array($aarr)) {
 		$arrayout = false;
 		$aarr = array($aarr);
@@ -2026,13 +2026,26 @@ function prettysigfig($aarr,$sigfig,$comma=',',$choptrailing=false,$orscinot=fal
 
 		$v = floor(-log10($a)-1e-12);
 		if ($v+$sigfig <= 0) {
-			if ($v<-16 && $scinot=='') { //special handling of really huge numbers
-				$multof3 = floor(-($v+$sigfig)/3);
-				$tmp = round($a/pow(10,$multof3*3), $v+$sigfig+$multof3*3);
-				$out[] = $sign.number_format($tmp,0,'.',$comma).str_repeat(',000',$multof3).$scinot;
-			} else {
-				$out[] = $sign.number_format(round($a,$v+$sigfig),0,'.',$comma).$scinot;
-			}
+      $multof3 = floor(-($v+$sigfig)/3);
+      $tmp = round($a/pow(10,$multof3*3), $v+$sigfig+$multof3*3);
+      $a = number_format($tmp,0,'.',$comma).str_repeat($comma.'000',$multof3);
+      if ($sigfigbar) {
+        //number of digits before first comma
+        $digbc = floor((log10($a)+1)%3)+3*((log10($a)+1)%3==0);
+        $anums = preg_replace('/[^\d]/','',$a);
+        if ($comma != '') {
+          //number of commas before sigfig digit
+          $acom = ($sigfig>$digbc)+floor(($sigfig-1-$digbc)/3)*($sigfig>$digbc);
+        } else {
+          $acom = 0;
+        }
+        if (isset($anums[$sigfig]) && $anums[$sigfig] === '0' && $anums[$sigfig-1] === '0') {
+          $a = substr_replace($a, 'overline(0)', $sigfig-1+$acom*strlen($comma), 1);
+        } elseif ($anums[$sigfig-1] === '0' && !isset($anums[$sigfig])) {
+          $a = $a.".";
+        }
+      }
+      $out[] = $sign.$a.$scinot;
 		} else {
 			$nv = round($a, $v+$sigfig);
 			$n = number_format($a,$v+$sigfig,'.',$comma);

--- a/help.html
+++ b/help.html
@@ -2423,8 +2423,8 @@ The following macros help with formatting values for display:
    can only be used for display, not in calculations.  By default adds a comma as a thousands separator; set comma to "" to override.</li>
 <li><strong>prettysmallnumber(number, [space])</strong>:  Prevents very small numbers from being displayed as scientific notation.
    Set space to true to add space in groups of 3, like 0.000 000 02</li>
-<li><strong>prettysigfig(number,sigfigs,[comma,choptrailingzeros])</strong>:  Rounds number to sigfigs significant figures.  By default it adds commas in thousands spaces; set comma to "" override.
-   Set choptrailingzeros to true to chop trailing zeros from the decimal part, even if significant.
+<li><strong>prettysigfig(number,sigfigs,[comma,choptrailingzeros,scinot,sigfigbar])</strong>:  Rounds number to sigfigs significant figures.  By default it adds commas in thousands spaces; set comma to "" to override.
+   Set choptrailingzeros to true to chop trailing zeros from the decimal part, even if significant. Set scinot to true to display in scientific notation. Set sigfigbar to true to put line over last significant, non-terminating zero, such as 42<span style="text-decoration: overline">0</span>0 having three sig figs (use only in math display).
    This is for display; to round a number for calculations, use roundsigfig.</li>
 <li><strong>makescinot(number,[decimals,format])</strong>:  Converts number to scientific notation.  If provided, rounds mantissa to decimals places.  Can specify format: "*" "E" as alternative to default cross.</li>
 <li><strong>prettytime(value,informat,outformat)</strong>:  Creates a nice representation of a time.  Informat can be 'h', 'm', or 's' designating whether


### PR DESCRIPTION
This adds an option in prettysigfig() for displaying line over last non-terminating, significant zero, such as in the 1st and 3rd items in the first list [here](https://en.wikipedia.org/wiki/Significant_figures#Ways_to_denote_significant_figures_in_an_integer_with_trailing_zeros). That is, it will put a bar over the first zero in 6700 to indicate three significant digits, and will put a decimal point at the end of 6700 to indicate four significant digits. Works whether or not a comma symbol/string is set.

These commits also fix an issue where unsetting a comma symbol would make 400000000000000000 display like 400000,000,000,000,000 if, say, 4 sigfigs is set in prettysigfig().