### PR TITLE
fix alt text to mention right angle box in triangles with no other la…

### DIFF
--- a/assessment/libs/shapes.php
+++ b/assessment/libs/shapes.php
@@ -1893,7 +1893,7 @@ function draw_triangle() {
             }
           }
         }
-      } elseif ($hasAltSidLab !== true && $hasAltAngLab !== true) {
+      } elseif ($hasPerp === true && $hasAltSidLab !== true && $hasAltAngLab !== true) {
         $alt .= " One angle is labeled with a right angle box.";
       }
     }

--- a/assessment/libs/shapes.php
+++ b/assessment/libs/shapes.php
@@ -1861,6 +1861,9 @@ function draw_triangle() {
             $alt .= ($i == 0) ? " a" : " A";
             $alt .= " side".$altMark[$i]." is unlabeled".$altVerLabNoAngle[$i];
           }
+          if ($hasPerp === true && $i == $perpKey) {
+            $alt .= " with its opposite angle labeled with a right angle box";
+          }
           $alt .= ".";
           if ($hasAltitude === true) {
             if ($altitudes[$i] == 1) {
@@ -1890,6 +1893,8 @@ function draw_triangle() {
             }
           }
         }
+      } elseif ($hasAltSidLab !== true && $hasAltAngLab !== true) {
+        $alt .= " One angle is labeled with a right angle box.";
       }
     }
   } else {


### PR DESCRIPTION
…bels

The auto-generated alt text didn't mention the right angle box in cases where no angles or sides were labeled. This commit fixes that.