### PR TITLE
Added a comparenumberswithunits function

### DIFF
--- a/assessment/macros.php
+++ b/assessment/macros.php
@@ -36,7 +36,7 @@ array_push($GLOBALS['allowedmacros'],"exp","sec","csc","cot","sech","csch","coth
  "mergeplots","array_unique","ABarray","scoremultiorder","scorestring","randstate",
  "randstates","prettysmallnumber","makeprettynegative","rawurlencode","fractowords",
  "randcountry","randcountries","sorttwopointdata","addimageborder","formatcomplex",
- "array_values","comparelogic","stuansready","comparentuples","isset","atan2");
+ "array_values","comparelogic","stuansready","comparentuples","comparenumberswithunits","isset","atan2");
 
 function mergearrays() {
 	$args = func_get_args();
@@ -5057,6 +5057,27 @@ function comparentuples() {
   }
   if ($correct == $dim) {
     return true;
+  }
+}
+
+function comparenumberswithunits($unitExp1, $unitExp2, $tol='0.001') {
+  require_once(__DIR__.'/../assessment/libs/units.php');
+  if (strval($tol)[0]=='|') {
+    $abstolerance = floatval(substr($tol,1));
+  }
+  [$unitVal1, $unitArray1] = parseunits($unitExp1);
+  [$unitVal2, $unitArray2] = parseunits($unitExp2);
+  if ($unitArray1 !== $unitArray2) {return false;}
+  if ($unitArray1 === $unitArray2) {
+    if (isset($abstolerance)) {
+      if (abs($unitVal1 - $unitVal2) < $abstolerance+1E-12) {
+        return true;
+      }
+    } else {
+      if (abs($unitVal1 - $unitVal2)/abs($unitVal1+0.0001) < $tol+1E-12 && abs($unitVal1 - $unitVal2)/abs($unitVal2+0.0001) < $tol+1E-12) {
+        return true;
+      }
+    }
   }
 }
 

--- a/help.html
+++ b/help.html
@@ -2596,6 +2596,10 @@ These macros are used to test various conditions.  They typically return true or
     allows the function to handle special cases like matrices better.</li>
 <li><strong>comparenumbers(a,b,[tol])</strong>:  Compares numbers or numerical expressions a and b to see if there are equivalent to the specified
   tolerance.  Set tol to specify the relative tolerance (defaults to .001), or prefix with | for an absolute tolerance.</li>
+<li><strong>comparenumberswithunits(a,b,[tol])</strong>:  Compares numbers-with-units a and b to see if they are equivalent to the specified tolerance. Set tol to 
+	specify the relative tolerance (defaults to .001), or prefix with | for an absolute tolerance. Each of a and b must be of the form: 
+	<code>[decimal number]*[unit]^[power]*[unit]^[power].../[unit]^[power]*[unit]^[power]...</code>, though 'per' may be used for division of units, and 'unit squared', 'square unit',
+	'unit cubed' and 'cubic unit' may be used. Examples: <code>4 cm</code>, and <code>3.5E4 feet per second squared</code>
 <li><strong>comparentuples(a,b,[tol],[option])</strong>:  Compares ntuples or calcntuples a and b to see if they are equivalent to the specified
 	  tolerance.  Set a single tol to specify the relative tolerance for all entries in ntuple (defaults to .001), or prefix with | for an absolute tolerance,
 		such as "|0.5". Can make tol an array (or list) to apply by element to the ntuple. By default, function compares the parentheses/brackets containing the
@@ -2966,8 +2970,9 @@ The answer is compared to a given tolerance.  Can also accept DNE, oo (Infinity)
             <li>$answerformat = "units" adds unit checking.  Supply the answer like <code>$answer = "3 kg/m^2"</code>.  
                 The student's answer can be in other equivalent units, so "300 cm" is considered equivalent to "3 m".
                 The answer must be in the format <code>[decimal number]*[unit]^[power]*[unit]^[power].../[unit]^[power]*[unit]^[power]...</code>, 
-                though multiplication can be implied.  Note that the units do not require mathematically-proper parens around the denominator.
-                The decimal number can include basic scientific notation in 3E5 or 3*10^5 formats.
+                though multiplication can be implied.  Also, 'per' may be used for division of units, and 'unit squared', 'square unit',
+								'unit cubed' and 'cubic unit' may be used. Note that the units do not require mathematically-proper parens around the denominator.
+                The decimal number can include basic scientific notation in 3E5 or 3*10^5 formats. Examples: <code>4 cm</code>, and <code>3.5E4 feet per second squared</code>
                 Note that tolerances are scaled to the unit, so $answer = "3m" with $abstolerance = .1 would mean 
                 .1 meters, so "310cm" would still be within tolerance.  If $reqsigfigs is set, the specified 
                 number of sigfigs will need to be present in the student's answer, regardless of units.


### PR DESCRIPTION
Here's a comparenumberswithunits() function.

I thought this could be helpful in conditional-type problems where partial credit is to be earned for writing an equivalent measurement with units. Like the other compare...() functions, this allows for a relative or absolute tolerance.

When used, it calls the libs/units.php file, so it can be used whether or not the answerformat includes "units".

Do you think this could be useful?