### PR TITLE
fixed alt text wording for triangle altitudes

### DIFF
--- a/assessment/libs/shapes.php
+++ b/assessment/libs/shapes.php
@@ -1826,7 +1826,7 @@ function draw_triangle() {
           if ($altitudes[$i] == 1) {
             $altAltLab[$i] = (!empty($altitudes[$i+3])) ? " labeled ".$altitudes[$i+3]." " : "";
             $altAltPtLab[$i] = (!empty($altitudes[$i+6])) ? " at point ".$altitudes[$i+6] : "";
-            $alt .= " An altitude".$altAltLab[$i]." is drawn from that angle's vertex to its opposite side".$altAltPtLab[$i];
+            $alt .= " An altitude".$altAltLab[$i]." is drawn from that angle's vertex to the line containing its opposite side".$altAltPtLab[$i];
             $alt .= ($medians[$i] == 1 || $bisectors[$i] == 1) ? "," : ".";
             $alt .= (($medians[$i] == 1 || $bisectors[$i] == 1) && !($medians[$i] == 1 && $bisectors[$i] == 1)) ? " and " : " ";
           }


### PR DESCRIPTION
Small change: The alt text used to say that an altitude connected to "the opposite side", but I've corrected that to "the line containing the opposite side".