### PR TITLE
Allow for superscript charges

### DIFF
--- a/assessment/libs/chemistry.php
+++ b/assessment/libs/chemistry.php
@@ -10,6 +10,7 @@ array_push($allowedmacros,"chem_disp","chem_mathdisp","chem_isotopedisp","chem_g
 //formats a compound for display in as HTML
 function chem_disp($c) {
 	$c = preg_replace('/_(\d+)/','<sub>$1</sub>',$c);
+	$c = preg_replace('/\^(\d\+|\d\-)|\^(\+|\-)/','<sup>$1</sup>',$c);
 	return str_replace(' ','',$c);
 }
 

--- a/assessment/libs/chemistry.php
+++ b/assessment/libs/chemistry.php
@@ -1,7 +1,7 @@
 <?php
 //A collection of chemistry routines
 //
-//Version 0.3 October 19, 2021
+//Version 0.31 May 7, 2022
 
 global $allowedmacros;
 array_push($allowedmacros,"chem_disp","chem_mathdisp","chem_isotopedisp","chem_getsymbol","chem_getnumber","chem_getname","chem_getweight","chem_getmeltingpoint","chem_getboilingpoint","chem_getfamily","chem_randelementbyfamily","chem_diffrandelementsbyfamily", "chem_getrandcompound", "chem_getdiffrandcompounds","chem_decomposecompound","chem_getcompoundmolmass","chem_randanion","chem_randcation","chem_makeioniccompound");
@@ -10,7 +10,7 @@ array_push($allowedmacros,"chem_disp","chem_mathdisp","chem_isotopedisp","chem_g
 //formats a compound for display in as HTML
 function chem_disp($c) {
 	$c = preg_replace('/_(\d+)/','<sub>$1</sub>',$c);
-	$c = preg_replace('/\^(\d\+|\d\-)|\^(\+|\-)/','<sup>$1</sup>',$c);
+	$c = preg_replace('/\^(\d+\+|\d+\-|\+|\-)/','<sup>$1</sup>',$c);
 	return str_replace(' ','',$c);
 }
 


### PR DESCRIPTION
Adds regex to allow for superscript charges in HTML display chemistry library macro of the form digit+, digit-, +, or -.