### PR TITLE
makes stuansready catch empty drawing in conditional

### DIFF
--- a/assessment/macros.php
+++ b/assessment/macros.php
@@ -5694,6 +5694,9 @@ function stuansready($stu, $qn, $parts, $anstypes = null, $answerformat = null) 
                         continue;
                     }
                 }
+            }
+            if ($anstypes !== null && $anstypes[$v] === 'draw' && str_replace(';','',$stu[$qn][$v]) === '') {
+              return false;
             } 
             //echo $stu[$qn][$v];
             if ($anstypes !== null && ($anstypes[$v] === 'matrix' || $anstypes[$v] === 'calcmatrix') &&


### PR DESCRIPTION
I noticed that stuansready was returning true for drawing parts submitted blank in conditional problems. Of course, feel free to deny/close this if there's a better way to fix it.