### PR TITLE
create parseStuansAsMatrix()

### DIFF
--- a/assessment/libs/matrix.php
+++ b/assessment/libs/matrix.php
@@ -16,7 +16,7 @@ array_push($allowedmacros,"matrix","matrixformat","matrixformatfrac","matrixsyst
 	"matrixIsRowsLinInd","matrixIsColsLinInd","matrixIsEigVec","matrixIsEigVal",
 	"matrixGetRowSpace","matrixGetColumnSpace","matrixFromEigenvals","matrixFormatEigenvecs",
 	"matrixAxbHasSolution","matrixAspansB","matrixAbasisForB",
-	"matrixGetMinor","matrixDet","matrixRandomMatrix","matrixParseStuans");
+	"matrixGetMinor","matrixDet","matrixRandomMatrix","matrixParseStuans","parseStuansAsMatrix");
 
 //matrix(vals,rows,cols)
 //Creates a new matrix item.
@@ -1440,6 +1440,17 @@ function matrixParseStuans($stu) {
             return explode('|', $stu);
         }
         */
+    }
+}
+
+function parseStuansAsMatrix ($stu) {
+	if ($stu === null) {
+		return matrix(array(), 0, 0);
+	} else {
+		echo $stu;
+        list($arr,$nrows) = parseMatrixToArray($stu);
+		$ncols = count($arr) / $nrows;
+        return matrix($arr, $nrows, $ncols);
     }
 }
 


### PR DESCRIPTION
As per the discussion [in this forum](https://www.myopenmath.com/forums/posts.php?view=0&cid=1&page=1&forum=374413&thread=1347456&r=64b1712993c82), I've created a function that takes a student-supplied calculated matrix and returns it *as a matrix* rather than as an array.

I have not updated the documentation.  Is that done by manually updating the HTML?  If so, we could put something like this in there:

```html
<h3><a name="parseStuansAsMatrix">parseStuansAsMatrix</a></h3>
<p>parseStuansAsMatrix(student answer)</p>
<p>Converts a students matrix answer into a matrix</p>
<p>student answer can come from <code>$stuanswers[$thisq]</code> for single-part
questions, or <code>getstuans($stuanswers, $thisq, (part index))</code> for
multi-part</p>
```