### PR TITLE
Allow the Canvas OIDC hostname to be set in config.

### DIFF
--- a/lti/Database.php
+++ b/lti/Database.php
@@ -136,8 +136,8 @@ class Imathas_LTI_Database implements LTI\Database
         if ($row === false || $row === null) {
             if (!empty($GLOBALS['CFG']['LTI']['autoreg']) && trim($client_id) != '') {
                 $canvas_oidc_hostname = $GLOBALS['CFG']['LTI']['canvas/oidc/prod'] ?? 'canvas.instructure.com';
-                $canvas_beta_oidc_hostname = $GLOBALS['CFG']['LTI']['canvas/oidc/prod'] ?? 'canvas.beta.instructure.com';
-                $canvas_test_oidc_hostname = $GLOBALS['CFG']['LTI']['canvas/oidc/prod'] ?? 'canvas.test.instructure.com';
+                $canvas_beta_oidc_hostname = $GLOBALS['CFG']['LTI']['canvas/oidc/beta'] ?? 'canvas.beta.instructure.com';
+                $canvas_test_oidc_hostname = $GLOBALS['CFG']['LTI']['canvas/oidc/test'] ?? 'canvas.test.instructure.com';
 
                 if ($iss === 'https://canvas.instructure.com') {
                     $row = [

--- a/lti/Database.php
+++ b/lti/Database.php
@@ -135,29 +135,33 @@ class Imathas_LTI_Database implements LTI\Database
         $row = $stm->fetch(PDO::FETCH_ASSOC);
         if ($row === false || $row === null) {
             if (!empty($GLOBALS['CFG']['LTI']['autoreg']) && trim($client_id) != '') {
+                $canvas_oidc_hostname = $GLOBALS['CFG']['LTI']['canvas/oidc/prod'] ?? 'canvas.instructure.com';
+                $canvas_beta_oidc_hostname = $GLOBALS['CFG']['LTI']['canvas/oidc/prod'] ?? 'canvas.beta.instructure.com';
+                $canvas_test_oidc_hostname = $GLOBALS['CFG']['LTI']['canvas/oidc/prod'] ?? 'canvas.test.instructure.com';
+
                 if ($iss === 'https://canvas.instructure.com') {
                     $row = [
                        'issuer' => $iss,
                        'client_id' => trim($client_id),
-                       'auth_login_url' => 'https://canvas.instructure.com/api/lti/authorize_redirect',
-                       'auth_token_url' => 'https://canvas.instructure.com/login/oauth2/token',
-                       'key_set_url' => 'https://canvas.instructure.com/api/lti/security/jwks'
+                       'auth_login_url' => sprintf('https://%s/api/lti/authorize_redirect', $canvas_oidc_hostname),
+                       'auth_token_url' => sprintf('https://%s/login/oauth2/token', $canvas_oidc_hostname),
+                       'key_set_url' => sprintf('https://%s/api/lti/security/jwks', $canvas_oidc_hostname)
                     ];
                 } else if ($iss === 'https://canvas.beta.instructure.com') {
                     $row = [
                        'issuer' => $iss,
                        'client_id' => trim($client_id),
-                       'auth_login_url' => 'https://canvas.beta.instructure.com/api/lti/authorize_redirect',
-                       'auth_token_url' => 'https://canvas.beta.instructure.com/login/oauth2/token',
-                       'key_set_url' => 'https://canvas.beta.instructure.com/api/lti/security/jwks'
+                       'auth_login_url' => sprintf('https://%s/api/lti/authorize_redirect', $canvas_beta_oidc_hostname),
+                       'auth_token_url' => sprintf('https://%s/login/oauth2/token', $canvas_beta_oidc_hostname),
+                       'key_set_url' => sprintf('https://%s/api/lti/security/jwks', $canvas_beta_oidc_hostname)
                     ];
                 } else if ($iss === 'https://canvas.test.instructure.com') {
                     $row = [
                        'issuer' => $iss,
                        'client_id' => trim($client_id),
-                       'auth_login_url' => 'https://canvas.test.instructure.com/api/lti/authorize_redirect',
-                       'auth_token_url' => 'https://canvas.test.instructure.com/login/oauth2/token',
-                       'key_set_url' => 'https://canvas.test.instructure.com/api/lti/security/jwks'
+                       'auth_login_url' => sprintf('https://%s/api/lti/authorize_redirect', $canvas_test_oidc_hostname),
+                       'auth_token_url' => sprintf('https://%s/login/oauth2/token', $canvas_test_oidc_hostname),
+                       'key_set_url' => sprintf('https://%s/api/lti/security/jwks', $canvas_test_oidc_hostname)
                     ];
                 }
                 if (is_array($row)) { // set something above - create platform reg

--- a/lti/admin/platforms.php
+++ b/lti/admin/platforms.php
@@ -216,9 +216,11 @@ if (empty($CFG['LTI']['autoreg'])) {
     echo '<li><label>'._('Details value (Client ID):').' <input name=canvas_clientid size=50/></label></li>';
     echo '</ul>';
     echo '<input type="hidden" name=canvas_issuer value="https://canvas.instructure.com"/>';
-    echo '<input type="hidden" name=canvas_keyseturl value="https://canvas.instructure.com/api/lti/security/jwks"/>';
-    echo '<input type="hidden" name=canvas_tokenurl value="https://canvas.instructure.com/login/oauth2/token"/>';
-    echo '<input type="hidden" name=canvas_authurl value="https://canvas.instructure.com/api/lti/authorize_redirect"/>';
+
+    $canvas_oidc_hostname = $CFG['LTI']['canvas/oidc/prod'] ?? 'canvas.instructure.com';
+    printf ('<input type="hidden" name=canvas_keyseturl value="https://%s/api/lti/security/jwks"/>', $canvas_oidc_hostname);
+    printf ('<input type="hidden" name=canvas_tokenurl value="https://%s/login/oauth2/token"/>', $canvas_oidc_hostname);
+    printf ('<input type="hidden" name=canvas_authurl value="https://%s/api/lti/authorize_redirect"/>', $canvas_oidc_hostname);
 
     echo '<input type="hidden" name=canvas_uniqid value="" />';
 


### PR DESCRIPTION
This is to support Canvas' new OIDC auth endpoints for LTI 1.3.

Use the following variables in config to set hostnames:
- `$CFG['LTI']['canvas/oidc/prod'] = 'sso.canvaslms.com';`
- `$CFG['LTI']['canvas/oidc/beta'] = 'sso.beta.canvaslms.com';`
- `$CFG['LTI']['canvas/oidc/test'] = 'sso.test.canvaslms.com';`

If the above variables are not set, default to the original
hostnames:
- canvas.instructure.com
- canvas.beta.instructure.com
- canvas.test.instructure.com