### PR TITLE
Increase the max length for reading QSETIDS on library imports.

### DIFF
--- a/admin/importlib.php
+++ b/admin/importlib.php
@@ -328,8 +328,7 @@ function parselibs($file) {
 			$libitemid = rtrim(fgets($handle, 4096));
 		} else if ($line=="QSETIDS") {
 			if ($libitemid!=-1) {
-                $readLength = $GLOBALS['CFG']['libimport']['qsetids_max_length'] ?? 4096;
-				$libitems[$libitemid] = rtrim(fgets($handle, $readLength));
+				$libitems[$libitemid] = rtrim(fgets($handle, 32768));
 			}
 		} else if ($dopackd ==true) {
 			$packname .= rtrim($line);

--- a/admin/importlib.php
+++ b/admin/importlib.php
@@ -328,7 +328,8 @@ function parselibs($file) {
 			$libitemid = rtrim(fgets($handle, 4096));
 		} else if ($line=="QSETIDS") {
 			if ($libitemid!=-1) {
-				$libitems[$libitemid] = rtrim(fgets($handle, 4096));
+                $readLength = $GLOBALS['CFG']['libimport']['qsetids_max_length'] ?? 4096;
+				$libitems[$libitemid] = rtrim(fgets($handle, $readLength));
 			}
 		} else if ($dopackd ==true) {
 			$packname .= rtrim($line);


### PR DESCRIPTION
This increase the max length for reading QSETIDS on library imports from `4096` to `32768`.