### PR TITLE
Added one-time blank-parts warning with bypass

### DIFF
--- a/assess2/vue-src/src/components/ErrorDialog.vue
+++ b/assess2/vue-src/src/components/ErrorDialog.vue
@@ -53,6 +53,10 @@ export default {
       return (typeof this.errormsg === 'string');
     },
     errorTitle () {
+      // show a "Warning" title for blankparts
+      if (this.errormsg === 'blankparts') {
+        return this.$t('Warning');
+      }
       return this.isError ? this.$t('error.error') : this.errormsg.title;
     },
     errorMsg () {

--- a/assess2/vue-src/src/locales/en.json
+++ b/assess2/vue-src/src/locales/en.json
@@ -166,6 +166,7 @@
   },
   "error": {
     "error": "Error",
+    "warning": "Warning",
     "invalid_password": "The password you entered was invalid",
     "invalid_aid": "Invalid assessment ID",
     "no_access": "You must be a student, teacher, or tutor to access this assessment",
@@ -187,6 +188,7 @@
     "lti_no_session": "Your session expired. Please go back to your LMS and open the assignment again.",
     "fast_regen": "Hey, how about slowing down and trying the problem before hitting Get a Similar Question?  Wait 5 seconds before trying again.",
     "nochange": "Your answers have not changed since your last submission.",
+    "blankparts": "Some parts are unanswered; submitting again will bypass this warning.",
     "noserver": "The site is not responding",
     "parseerror": "Server sent an invalid response",
     "livepoll_wrongquestion": "Submitted question is not the current question.",


### PR DESCRIPTION
Description:
Show a “Warning” dialog when a student submits with any parts blank, but only on the first click—subsequent submits go through.
	•	Store: add blankOverride flag in basicstore.js
	•	Guard: on first partial submit set errorMsg='blankparts' + blankOverride=true; on next submit clear it and proceed
	•	Reset: clear blankOverride when all parts are filled, a new question loads, or a full submit succeeds
	•	UI: update en.json to label the dialog “Warning” and adjust the message; tweak ErrorDialog.vue to use that title

How to test:
1. Load a multipart question.
2. Submit with some blanks → see the warning once.
3. Submit again → it submits.
4. Click **Get a similar question** to load a new question.
5. Repeat steps 2–3 on the regenerated question to verify the warning appears again.