### PR TITLE
Fix.forumlastchanged Forum Last Change columns for the Gradebook Export

### DIFF
--- a/course/gb-export.php
+++ b/course/gb-export.php
@@ -70,7 +70,7 @@
 			<option value=2>Include time in questions</option>
 			</select></span><br class="form" />';
         
-		echo '<label class="form" for="lastchanged">Include assessment and discussion last changed dates?:</label>';
+		echo '<label class="form" for="lastchanged">Include assessment last changed dates?:</label>';
 		echo '<span class="formright"><select id=lastchanged name=lastchanged>
 			<option value=0 selected>No</option>
 			<option value=1>Yes</option>

--- a/course/gb-export.php
+++ b/course/gb-export.php
@@ -70,7 +70,7 @@
 			<option value=2>Include time in questions</option>
 			</select></span><br class="form" />';
         
-		echo '<label class="form" for="lastchanged">Include assessment last changed dates?:</label>';
+		echo '<label class="form" for="lastchanged">Include assessment and discussion last changed dates?:</label>';
 		echo '<span class="formright"><select id=lastchanged name=lastchanged>
 			<option value=0 selected>No</option>
 			<option value=1>Yes</option>
@@ -499,7 +499,7 @@ function gbinstrdisp() {
 				$pointsrow .= '<th></th>';
 				$n++;
 			}
-            if ($includelastchange && $gbt[0][1][$i][6]==0) {
+            if ($includelastchange && ($gbt[0][1][$i][6]==0 || $gbt[0][1][$i][6]==2)) {
                 echo '<th>'. $gbt[0][1][$i][0].': Last Changed'.'</th>';
                 $pointsrow .= '<th></th>';
 				$n++;
@@ -660,7 +660,7 @@ function gbinstrdisp() {
 					}
 					$n++;
 				}
-                if ($includelastchange>0 && $gbt[0][1][$j][6]==0) {
+                if ($includelastchange>0 && ($gbt[0][1][$j][6]==0 || $gbt[0][1][$j][6]==2)) {
                     if (!empty($gbt[$i][1][$j][9])) {
                         echo '<td>'.date('Y-m-d g:i a', $gbt[$i][1][$j][9]).'</td>';
                     } else {

--- a/course/gbtable2.php
+++ b/course/gbtable2.php
@@ -1760,10 +1760,10 @@ function gbtable() {
 	if (isset($GLOBALS['includelastchange']) && $GLOBALS['includelastchange']==true && count($discuss)>0) {
 		$forumidlist = implode(',', array_map('intval', $discuss)); //values from DB
 		if ($limuser>0) {
-			$stm2 = $DBH->prepare("SELECT forumid, userid, MAX(postdate) as lastpostdate FROM imas_forum_posts WHERE forumid IN ($forumidlist) AND userid=:userid AND posttype>0 GROUP BY forumid, userid");
+			$stm2 = $DBH->prepare("SELECT forumid, userid, MAX(postdate) as lastpostdate FROM imas_forum_posts WHERE forumid IN ($forumidlist) AND userid=:userid GROUP BY forumid, userid");
 			$stm2->execute(array(':userid'=>$limuser));
 		} else {
-			$stm2 = $DBH->query("SELECT forumid, userid, MAX(postdate) as lastpostdate FROM imas_forum_posts WHERE forumid IN ($forumidlist) AND posttype>0 GROUP BY forumid, userid");
+			$stm2 = $DBH->query("SELECT forumid, userid, MAX(postdate) as lastpostdate FROM imas_forum_posts WHERE forumid IN ($forumidlist) GROUP BY forumid, userid");
 		}
 		while ($l = $stm2->fetch(PDO::FETCH_ASSOC)) {
 			if (!isset($discussidx[$l['forumid']]) || !isset($sturow[$l['userid']]) || !isset($discusscol[$l['forumid']])) {

--- a/course/gbtable2.php
+++ b/course/gbtable2.php
@@ -1756,6 +1756,26 @@ function gbtable() {
 		}
 	}
 
+	//Get forum last changed dates
+	if (isset($GLOBALS['includelastchange']) && $GLOBALS['includelastchange']==true && count($discuss)>0) {
+		$forumidlist = implode(',', array_map('intval', $discuss)); //values from DB
+		if ($limuser>0) {
+			$stm2 = $DBH->prepare("SELECT forumid, userid, MAX(postdate) as lastpostdate FROM imas_forum_posts WHERE forumid IN ($forumidlist) AND userid=:userid AND posttype>0 GROUP BY forumid, userid");
+			$stm2->execute(array(':userid'=>$limuser));
+		} else {
+			$stm2 = $DBH->query("SELECT forumid, userid, MAX(postdate) as lastpostdate FROM imas_forum_posts WHERE forumid IN ($forumidlist) AND posttype>0 GROUP BY forumid, userid");
+		}
+		while ($l = $stm2->fetch(PDO::FETCH_ASSOC)) {
+			if (!isset($discussidx[$l['forumid']]) || !isset($sturow[$l['userid']]) || !isset($discusscol[$l['forumid']])) {
+				continue;
+			}
+			$row = $sturow[$l['userid']];
+			$col = $discusscol[$l['forumid']];
+			
+			$gb[$row][1][$col][9] = $l['lastpostdate'];
+		}
+	}
+
 	//pull excusals
 	$excused = array();
     $hasexcused = array();


### PR DESCRIPTION
Addresses the issue we are having where Forums/Discussions do not have a Last Changed column added to the Gradebook Export when that option is selected. The assessments have Last Changed columns added and populated, but discussions are currently exported as a single column. These missing Last Changed columns for forum/discussion items is causing our LMS gradebook import to have issues because it is expecting the same structure which is used for Assessments.
<img width="418" height="81" alt="image" src="https://github.com/user-attachments/assets/06bf5a8a-89cb-4374-8d36-2c0506077bc7" />


This pull request adds Forum/Discussion Last Changed columns to the Gradebook Export
<img width="2138" height="150" alt="Screenshot from 2026-06-01 10-45-28" src="https://github.com/user-attachments/assets/3eb9a254-bfe5-45bc-93a6-ef03078b8ebd" />


This code has been AI generated (using Claude Haiku 4.5). I have tested and revised this as much as I can and it works on my test environment, but it would greatly benefit from a careful look by someone with in-depth knowledge of the database and programming logic (fortunately it is short).