### PR TITLE
Add sticky headers and scrollabel content to course management pages

### DIFF
--- a/course/chgassessments2.php
+++ b/course/chgassessments2.php
@@ -717,6 +717,15 @@ div.warn {
 	margin-left: -2px;
 	margin-bottom: 2px;
 }
+
+#assesslist-scrollbox {
+    overflow-y: auto;
+    position: relative;
+    height: calc(100vh - 260px);
+    border-top: 1px solid #ccc;
+    margin-top: 6px;
+    padding-top: 6px;
+}
 ul.assessnest {
 	list-style-type: none;
 	padding-left: 0;
@@ -791,6 +800,17 @@ function tabToSettings() {
 		$(document).scrollTop(0);
 	}
 }
+
+function assessListSetLayout() {
+    var box = document.getElementById("assesslist-scrollbox");
+    if (!box) { return; }
+
+    var rect = box.getBoundingClientRect();
+    var h = window.innerHeight - rect.top - 12;
+    if (h < 250) { h = 250; }
+
+    box.style.height = h + "px";
+}
 $(function() {
 	$(".tablist a").on('click', function(ev) {
 		setActiveTab(this)
@@ -812,6 +832,10 @@ $(function() {
 			}
 		} 
 	});
+    assessListSetLayout();
+    setTimeout(assessListSetLayout, 100);
+    setTimeout(assessListSetLayout, 500);
+    $(window).on("resize", assessListSetLayout);
 });
 </script>
 
@@ -852,9 +876,11 @@ $(function() {
 		writeHtmlSelect ("selbygbcat",array_keys($gbcats),array_values($gbcats),null,"Select...",-1,' onchange="chkgbcat(this.value);" id="selbygbcat" ');
 		?>
 
-		<ul id="alistul" class="assessnest">
-		<?php echo $assessNestedList; ?>
-		</ul>
+		<div id="assesslist-scrollbox">
+			<ul id="alistul" class="assessnest">
+			<?php echo $assessNestedList; ?>
+			</ul>
+		</div>
 
 		<p>
 			Continue to <a href="#" role="button" onclick="tabToSettings();return false;">Change Settings</a>.

--- a/course/course.php
+++ b/course/course.php
@@ -393,6 +393,24 @@ if (isset($tutorid) && isset($_SESSION['ltiitemtype']) && $_SESSION['ltiitemtype
 	$placeinhead .= '<script type="text/javascript">$(function(){$(".instrdates").hide();});</script>';
 }
 
+// Keep the course header/title area and left navigation visible while only the item list scrolls.
+$placeinhead .= '<style type="text/css">
+#leftcontent {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  overflow-y: auto;
+}
+#centercontent {
+  margin-left: 220px;   /* adjust if your left panel is wider/narrower */
+}
+#courseitem-scrollbox {
+  overflow-y: auto;
+  position: relative;
+  height: calc(100vh - 180px);
+}
+</style>';
+
 /******* begin html output ********/
 require_once "../header.php";
 
@@ -644,6 +662,10 @@ if ($overwriteBody==1) {
    makeTopMenu();
    echo "<div id=\"headercourse\" class=\"pagetitle\"><h1>".Sanitize::encodeStringForDisplay($curname)."</h1></div>\n";
 
+
+   // Everything above this point stays visible; only the course items below scroll.
+   echo '<div id="courseitem-scrollbox">';
+
    if (count($items)>0) {
 
 
@@ -682,6 +704,31 @@ if ($overwriteBody==1) {
    if (isset($backlink)) {
 	   echo $backlink;
    }
+
+   echo "</div>"; //courseitem-scrollbox
+
+   echo '<script type="text/javascript">
+function courseSetLayout() {
+	var box = document.getElementById("courseitem-scrollbox");
+	if (!box) { return; }
+
+	var rect = box.getBoundingClientRect();
+	var h = window.innerHeight - rect.top - 8;
+	if (h < 250) { h = 250; }
+	box.style.height = h + "px";
+}
+if (typeof $ !== "undefined") {
+	$(function() {
+		courseSetLayout();
+		setTimeout(courseSetLayout, 100);
+		setTimeout(courseSetLayout, 500);
+	});
+	$(window).on("load resize", courseSetLayout);
+} else {
+	window.addEventListener("load", courseSetLayout);
+	window.addEventListener("resize", courseSetLayout);
+}
+</script>';
 
    echo "</div>"; //centercontent
 

--- a/course/manageqset.php
+++ b/course/manageqset.php
@@ -667,6 +667,25 @@ $placeinhead .= '<style>
   .qisprivate {
     color: #db0000;
   }
+  #qsl-scrollbox {
+  overflow-y: auto;
+  position: relative;
+  height: calc(100vh - 180px); /* fallback */
+  max-height: none;
+  }
+  #qsl-pdiv {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background: #fff;
+    padding-bottom: 6px;
+  }
+  #myTable thead th {
+    position: sticky;
+    top: var(--qsl-frozen-h, 0px);
+    z-index: 2;
+    background: #fff;
+  }
   </style>';
 require_once "../header.php";
 
@@ -930,7 +949,8 @@ if (isset($searchtype)) {
 		echo "<script type=\"text/javascript\" src=\"$staticroot/javascript/tablesorter.js?v=082913\"></script>\n";
 		echo "<form id=\"selq\" method=post action=\"manageqset.php?cid=$cid\">\n";
 		//echo "Check/Uncheck All: <input type=\"checkbox\" name=\"ca2\" value=\"1\" onClick=\"chkAll(this.form, 'nchecked[]', this.checked)\">\n";
-		echo '<div class=pdiv>Check: <a href="#" onclick="return chkAllNone(\'selq\',\'nchecked[]\',true)">All</a> <a href="#" onclick="return chkAllNone(\'selq\',\'nchecked[]\',false)">None</a> ';
+		echo '<div id="qsl-scrollbox">';
+		echo '<div id="qsl-pdiv" class=pdiv>Check: <a href="#" onclick="return chkAllNone(\'selq\',\'nchecked[]\',true)">All</a> <a href="#" onclick="return chkAllNone(\'selq\',\'nchecked[]\',false)">None</a> ';
 
         echo '<span class="dropdown">';
 		echo ' <a role=button tabindex=0 class="dropdown-toggle arrow-down" id="dropdownMenuWithsel" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">';
@@ -956,12 +976,37 @@ if (isset($searchtype)) {
                 <a href="#" id="searchprev" style="display:none">' . _('Previous Results'). ' </a>
                 <a href="#" id="searchnext" style="display:none">' . _('More Results'). ' </a>
             </p>';
+		echo '</div>'; // close #qsl-scrollbox
 		echo "</form>\n";
         echo '<script type="text/javascript">
+		function qslSetLayout() {
+		  var scrollbox = document.getElementById("qsl-scrollbox");
+		  var pdiv = document.getElementById("qsl-pdiv");
+		  if (!scrollbox || !pdiv) { return; }
+
+		  scrollbox.style.setProperty("--qsl-frozen-h", pdiv.offsetHeight + "px");
+
+		  var rect = scrollbox.getBoundingClientRect();
+		  var bottomBuffer = 8;
+		  var h = window.innerHeight - rect.top - bottomBuffer;
+
+		  if (h < 250) { h = 250; }
+		  scrollbox.style.height = h + "px";
+		}
             $(function() {
-                displayQuestionList(' . json_encode($search_results, JSON_INVALID_UTF8_IGNORE) . ');
-                setlibhistory();
+                try {
+                    displayQuestionList(' . json_encode($search_results, JSON_INVALID_UTF8_IGNORE) . ');
+                    setlibhistory();
+                } catch (e) {
+                    if (window.console) { console.error("manageqset list init error:", e); }
+                }
+                qslSetLayout();
+                // re-check shortly after in case fonts/images/async content shift the layout
+                setTimeout(qslSetLayout, 100);
+                setTimeout(qslSetLayout, 500);
             });
+            $(window).on("load", qslSetLayout);
+            $(window).on("resize", qslSetLayout);
             </script>';
 		echo "<p></p>\n";
 	}


### PR DESCRIPTION
This PR adds optional sticky-header/scrollable-content behavior to several instructor management pages to improve usability when working with large courses.

Changes include:

* `manageqset.php`

  * Freezes the controls and header row.
  * Makes the question list scrollable.

* `course.php`

  * Keeps the course title and view controls visible.
  * Makes the course item list scrollable.
  * Keeps the left navigation panel fixed.

* `chgassessments2.php`

  * Keeps the selection controls visible.
  * Makes the assessment list scrollable.

The changes are implemented with CSS and small JavaScript layout calculations borrowed from Gradebook which freezes the top row and first column.
