### PR TITLE
Add randkeyfrom and randkeysfrom macros and their descriptions in help.php

### DIFF
--- a/assessment/macros/randomizers.php
+++ b/assessment/macros/randomizers.php
@@ -9,7 +9,9 @@ array_push(
     'rands',
     'rrands',
     'randfrom',
+    'randkeyfrom',
     'randsfrom',
+    'randkeysfrom',
     'jointrandfrom',
     'diffrandsfrom',
     'nonzerorand',
@@ -138,6 +140,23 @@ function randfrom($lst) {
 }
 
 
+function randkeyfrom($lst) {
+    if (func_num_args() != 1) {
+        echo "randkeyfrom expects 1 argument";
+        return 1;
+    }
+    if (!is_array($lst)) {
+        echo "randkeyfrom expects an array";
+        return 1;
+    }
+    if (count($lst) == 0) {
+        echo 'cannot pick randkeyfrom empty array';
+        return '';
+    }
+    return $GLOBALS['RND']->array_rand($lst, 1);
+}
+
+
 function randsfrom($lst, $n, $ord = 'def') {
     if (func_num_args() < 2) {
         echo "randsfrom expects 2 arguments";
@@ -160,6 +179,27 @@ function randsfrom($lst, $n, $ord = 'def') {
         rsort($r);
     }
     return $r;
+}
+
+
+function randkeysfrom($lst, $n = 1) {
+    if (func_num_args() < 1) {
+        echo "randkeysfrom expects at least 1 argument";
+        return 1;
+    }
+    if (!is_array($lst)) {
+        echo "randkeysfrom expects an array";
+        return 1;
+    }
+    $n = floor($n);
+    if ($n <= 0) {
+        echo "randkeysfrom: need n &gt; 0";
+    }
+    if (count($lst) == 0) {
+        echo 'cannot pick randkeysfrom empty array';
+        return '';
+    }
+    return $GLOBALS['RND']->array_rand($lst, $n);
 }
 
 

--- a/help.html
+++ b/help.html
@@ -2332,6 +2332,8 @@ $n = randfrom("2,4,6,8")             // might return 4
 
 $arr = [10,20,30]
 $val = randfrom($arr)                // might return 20</pre></details></li>
+<li><strong>randkeyfrom(array)</strong>: Return a random key from the array.
+  <details class="example"><summary>Example</summary><pre>$x = randkeyfrom(["a"=>"A", "b"=>"B", "c"=>"C"])  // e.g. $x="b"</pre></details></li>
 <li><strong>randname(),randmalename(),randfemalename()</strong>:  Returns a random first name
   <details class="example"><summary>Example</summary><pre>$name = randname()       // might return "Sofia"
 $name = randmalename()   // might return "Carlos"
@@ -2369,6 +2371,9 @@ $a,$b = nonzerorands(-3,3,2,'inc')  // sorted: -1, 2</pre></details></li>
   <details class="example"><summary>Example</summary><pre>$a,$b = randsfrom("red,green,blue,yellow", 2)  // e.g. "blue", "red"
 $arr = [2,4,6,8]
 $a,$b = randsfrom($arr, 2, 'inc');         // sorted ascending, e.g. 2, 6</pre></details></li>
+<li><strong>randkeysfrom(array,n)</strong>: Return n random keys from the array.
+  <details class="example"><summary>Example</summary><pre>$arr = [0=>'x_0', 1=>'x_1', 2=>'x_2', 3=>'x_3']
+$a,$b = randkeysfrom($arr, 2);  // e.g., $a=2, $b=0</pre></details></li>
 <li><strong>jointrandfrom(list/array,list/array,[list/array,...])</strong>:  Returns one element from each list, where the location used in each list is the same
   <details class="example"><summary>Example</summary><pre>$first,$last = jointrandfrom("Alice,Bob,Carlos", "Smith,Jones,Rivera")
 // picks the same index from each list, so names stay paired:


### PR DESCRIPTION
## Summary
Adds two new randomizer macros for MyOpenMath: `randkeyfrom` and `randkeysfrom`.
These mirror PHP's `array_rand()`, but pull from MOM's seeded random generator
(`$GLOBALS['RND']`) so results stay reproducible for grading/regrading, consistent
with the rest of the macros in `randomizers.php`.

## New functions

**`randkeyfrom($array)`**
Returns a single random key from an array. Equivalent to `array_rand($array)`.

    $arr = ["a"=>"A", "b"=>"B", "c"=>"C"];
    $x = randkeyfrom($arr);  // e.g. $x = "b"

**`randkeysfrom($array, $n = 1)`**
Returns `$n` random keys from an array. Equivalent to `array_rand($array, $n)`.
Unlike PHP's native `array_rand()`, which requires `[$a, $b] = array_rand(...)`
for multiple keys, `randkeysfrom` returns a plain array so it works with MOM's
existing multi-assignment syntax:

    $arr = [0=>'x_0', 1=>'x_1', 2=>'x_2', 3=>'x_3'];
    $a,$b = randkeysfrom($arr, 2);   // e.g. $a=2, $b=0
    [$a,$b] = randkeysfrom($arr, 2); // e.g. $a=1, $b=3

`randkeysfrom` only accepts arrays (not comma-separated lists), since lists
have no keys — this differs from `randfrom`/`randsfrom`, which accept both.

## Files changed
- `assessment/macros/randomizers.php` — function definitions, added to `allowedmacros`
- `help.html` — documentation entries added after the existing `randfrom`/`randsfrom` entries

## Testing
Verified locally against QID 1141.